### PR TITLE
Added coredump remover, fixed crash in favorites menu when trying to leave it using "esc" key on cardputer.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -72,12 +72,9 @@ platforms_dir = .pio/platforms
 packages_dir = .pio/packages
 core_dir = .pio
 
-
 extra_configs =
 	boards/*.ini
 	boards/*/*.ini
-
-
 
 [env]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
@@ -112,7 +109,7 @@ lib_deps =
 	Wire
 	SD
 	FS
-	ESP32Async/ESPAsyncWebServer
+	ESP32Async/ESPAsyncWebServer @ ^3.0.0
 	bblanchon/ArduinoJson @ ^7.0.4
 	moononournation/GFX Library for Arduino @ ^1.5.5
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -832,8 +832,10 @@ int loopOptions(std::vector<Option> &options, bool bright, uint16_t al, uint16_t
             if (bright) { setBrightness(100 * (numOpt - index) / numOpt, false); }
             redraw = false;
         }
-        String txt = options[index].label;
-        displayScrollingText(txt, coord);
+        if (index >= 0 && index < static_cast<int>(options.size())) {
+            String txt = options[index].label;
+            displayScrollingText(txt, coord);
+        }
 
 #if defined(T_EMBED) || defined(HAS_TOUCH) || defined(HAS_KEYBOARD)
 #if defined(HAS_TOUCH)

--- a/src/onlineLauncher.cpp
+++ b/src/onlineLauncher.cpp
@@ -167,7 +167,7 @@ void ota_function() {
             }
             options.push_back({"Main Menu", [=]() { returnToMenu = true; }, ALCOLOR});
             idx = loopOptions(options, false, FGCOLOR, BGCOLOR, false, idx);
-            if (!returnToMenu) goto RELOAD;
+            if (!returnToMenu && idx != -1) goto RELOAD;
         } else {
             if (GetJsonFromLauncherHub()) loopFirmware();
         }
@@ -534,14 +534,13 @@ bool installExtFirmware(String url) {
 bool clearOnlineCoredump() {
     const esp_partition_t *partition =
         esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_ANY, "coredump");
-        Serial.printf("Coredump partition address: 0x%08X\n", partition ? partition->address : 0);
+    Serial.printf("Coredump partition address: 0x%08X\n", partition ? partition->address : 0);
     if (!partition) {
         Serial.println("Failed to find coredump partition");
         log_e("Failed to find coredump partition");
         return false;
     }
-    log_i("Erasing coredump partition at address 0x%08X, size %d bytes",
-          partition->address, partition->size);
+    log_i("Erasing coredump partition at address 0x%08X, size %d bytes", partition->address, partition->size);
 
     // erase all coredump partition
     esp_err_t err = esp_flash_erase_region(NULL, partition->address, partition->size);

--- a/src/onlineLauncher.h
+++ b/src/onlineLauncher.h
@@ -31,4 +31,6 @@ JsonDocument getVersionInfo(String fid);
 
 bool installFAT_OTA(WiFiClientSecure *client, String file, uint32_t offset, uint32_t size, const char *label);
 
+bool clearOnlineCoredump();
+
 #endif

--- a/src/sd_functions.cpp
+++ b/src/sd_functions.cpp
@@ -447,7 +447,11 @@ void performUpdate(Stream &updateSource, size_t updateSize, int command) {
             progressHandler(written, updateSize);
         }
         if (Update.end()) {
-            if (Update.isFinished()) log_i("Update successfully completed.");
+            if (Update.isFinished()) {
+                log_i("Update successfully completed. Rebooting.");
+                displayRedStripe("Removing coredump (if any)...");
+                clearCoredump();
+            }
             else log_i("Update not finished? Something went wrong!");
         } else {
             log_i("Error Occurred. Error #: %s", String(Update.getError()));
@@ -458,6 +462,37 @@ void performUpdate(Stream &updateSource, size_t updateSize, int command) {
         delay(2500);
     }
     vTaskResume(xHandle);
+}
+
+
+/***************************************************************************************
+ ** Function name: clearCoredump
+ ** Description:   As some programs may generate core dumps,
+                   and others try to report them thinking that they wrote it,
+                   this function will clear it to avoid confusion.
+****************************************************************************************/
+bool clearCoredump() {
+    const esp_partition_t *partition =
+        esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_ANY, "coredump");
+        Serial.printf("Coredump partition address: 0x%08X\n", partition ? partition->address : 0);
+    if (!partition) {
+        Serial.println("Failed to find coredump partition");
+        log_e("Failed to find coredump partition");
+        return false;
+    }
+    log_i("Erasing coredump partition at address 0x%08X, size %d bytes",
+          partition->address, partition->size);
+
+    // erase all coredump partition
+    esp_err_t err = esp_flash_erase_region(NULL, partition->address, partition->size);
+    if (err != ESP_OK) {
+        Serial.println("Failed to erase coredump partition");
+        log_e("Failed to erase coredump partition: %s", esp_err_to_name(err));
+        return false;
+    }
+    Serial.println("Coredump partition cleared successfully");
+    log_e("Coredump partition cleared successfully");
+    return true;
 }
 
 /***************************************************************************************

--- a/src/sd_functions.h
+++ b/src/sd_functions.h
@@ -35,4 +35,7 @@ void performUpdate(Stream &updateSource, size_t updateSize, int command);
 void updateFromSD(String path);
 
 bool performFATUpdate(Stream &updateSource, size_t updateSize, const char *label = "vfs");
+
+bool clearCoredump();
+
 #endif


### PR DESCRIPTION
Hi there!
This pull request includes following changes:

1.  Coredump partition eraser: After a new firmware is flashed, the coredump partition will be automatically erased. This approach guarantees that any firmware that relies on coredump for bug reports will function properly, and launcher can still be debugged.
2. Fixed bug where if you press "ESC" on cardputer-adv in favorites menu, firstly it will glitch out, then it will crash core 0.

Please write your changes that I need to include for you to merge this pull request below, or if this satisfies you, consider merging it.

Have a nice day!