### PR TITLE
Make launcher API host configurable

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -191,6 +191,8 @@ extern String wui_pwd;
 
 extern String dwn_path;
 
+extern String launcher_api_host;
+
 extern int currentIndex;
 
 extern uint16_t total_firmware; // Number of available firmware on the list

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -106,6 +106,7 @@ String pwd;
 String wui_usr = "admin";
 String wui_pwd = "launcher";
 String dwn_path = "/downloads/";
+String launcher_api_host = "launcherhub.svk.su";
 uint16_t total_firmware = 0;
 uint8_t current_page = 1;
 uint8_t num_pages = 0;

--- a/src/onlineLauncher.cpp
+++ b/src/onlineLauncher.cpp
@@ -202,7 +202,7 @@ bool getInfo(String serverUrl, JsonDocument &_doc) {
         resetTftDisplay();
         tft->drawRoundRect(5, 5, tftWidth - 10, tftHeight - 10, 5, FGCOLOR);
         tft->drawCentreString("Getting info from", tftWidth / 2, tftHeight / 3, 1);
-        tft->drawCentreString("LauncherHub", tftWidth / 2, tftHeight / 3 + FM * 9, 1);
+        tft->drawCentreString(launcher_api_host.c_str(), tftWidth / 2, tftHeight / 3 + FM * 9, 1);
         tft->display(false);
         tft->setCursor(18, tftHeight / 3 + FM * 9 * 2);
         const uint8_t maxAttempts = 5;
@@ -253,7 +253,7 @@ bool GetJsonFromLauncherHub(uint8_t page, String order, bool star, String query)
 #ifdef OTA_EXTRA
     q += OTA_EXTRA;
 #endif
-    String serverUrl = "https://api.launcherhub.net/firmwares?category=" + String(OTA_TAG) + q;
+    String serverUrl = "https://" + launcher_api_host + "/firmwares?category=" + String(OTA_TAG) + q;
 
     if (getInfo(serverUrl, doc)) {
         total_firmware = doc["total"].as<int>();
@@ -268,7 +268,7 @@ bool GetJsonFromLauncherHub(uint8_t page, String order, bool star, String query)
 }
 JsonDocument getVersionInfo(String fid) {
     JsonDocument versions;
-    String serverUrl = "https://api.launcherhub.net/firmwares?fid=" + fid;
+    String serverUrl = "https://" + launcher_api_host + "/firmwares?fid=" + fid;
     if (!getInfo(serverUrl, versions)) {
         displayRedStripe("Version fetch Failed");
         vTaskDelay(1500 / portTICK_PERIOD_MS);
@@ -281,7 +281,7 @@ JsonDocument getVersionInfo(String fid) {
 ***************************************************************************************/
 void downloadFirmware(String fid, String file, String fileName, String folder) { // Adicionar "fid"
     if (!file.startsWith("https://")) file = M5_SERVER_PATH + file;
-    String fileAddr = "https://api.launcherhub.net/download?fid=" + fid + "&file=" + file;
+    String fileAddr = "https://" + launcher_api_host + "/download?fid=" + fid + "&file=" + file;
     if (fid == "") fileAddr = file;
     int tries = 0;
     fileName = replaceChars(fileName);
@@ -578,7 +578,7 @@ void installFirmware( // adicionar "fid"
     bool fat, uint32_t fat_offset[2], uint32_t fat_size[2]
 ) {
     if (!file.startsWith("https://")) file = M5_SERVER_PATH + file;
-    String fileAddr = "https://api.launcherhub.net/download?fid=" + fid + "&file=" + file;
+    String fileAddr = "https://" + launcher_api_host + "/download?fid=" + fid + "&file=" + file;
     if (fid == "") fileAddr = file;
 
     // Release RAM Memory from Json Objects

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -117,6 +117,21 @@ bool setWifiCredential(const String &ssidValue, const String &passwordValue, boo
     return true;
 }
 
+void setApiHost() {
+    String customLabel = "Custom (" + launcher_api_host + ")";
+    options = {
+        {"launcherhub.svk.su",  [&]() { launcher_api_host = "launcherhub.svk.su"; }},
+        {"api.launcherhub.net", [&]() { launcher_api_host = "api.launcherhub.net"; }},
+        {customLabel.c_str(),   [&]() {
+            String newHost = keyboard(launcher_api_host, 128, "API Host:");
+            if (newHost != String(KEY_ESCAPE) && newHost.length() > 0) {
+                launcher_api_host = newHost;
+            }
+        }},
+    };
+    loopOptions(options);
+}
+
 void settings_menu() {
     options = {
 #ifndef E_PAPER_DISPLAY
@@ -190,6 +205,10 @@ void settings_menu() {
     if (MAX_FAT_vfs > 0) options.push_back({"Restore FAT Vfs", [=]() { restorePartition("vfs"); }});
     if (dev_mode) options.push_back({"Boot Animation", [=]() { initDisplayLoop(); }});
     if (dev_mode) options.push_back({"Deactivate Dev", [=]() { dev_mode = false; }});
+    options.push_back({"API Host", [=]() {
+        setApiHost();
+        saveConfigs();
+    }});
     options.push_back({"Restart", [=]() { FREE_TFT reboot(); }});
 #if defined(STICK_C_PLUS2) || defined(T_EMBED) || defined(STICK_C_PLUS) || defined(T_LORA_PAGER)
     options.push_back({"Turn-off", [=]() { powerOff(); }});
@@ -509,6 +528,7 @@ bool saveIntoNVS() {
     err |= nvsHandle->set_string("wui_usr", wui_usr.c_str());
     err |= nvsHandle->set_string("wui_pwd", wui_pwd.c_str());
     err |= nvsHandle->set_string("dwn_path", dwn_path.c_str());
+    err |= nvsHandle->set_string("api_host", launcher_api_host.c_str());
 #if defined(HEADLESS)
     // SD Pins
     err |= nvsHandle->set_item("miso", _miso);
@@ -610,6 +630,7 @@ void defaultValues() {
     wui_usr = "admin";
     wui_pwd = "launcher";
     dwn_path = "/downloads/";
+    launcher_api_host = "launcherhub.svk.su";
 #if defined(HEADLESS)
     // SD Pins
     _miso = 0;
@@ -658,6 +679,13 @@ bool getFromNVS() {
     wui_pwd = String(buffer);
     err |= nvsHandle->get_string("dwn_path", buffer, sizeof(buffer));
     dwn_path = String(buffer);
+    char hostBuffer[128] = {0};
+    esp_err_t hostErr = nvsHandle->get_string("api_host", hostBuffer, sizeof(hostBuffer));
+    if (hostErr == ESP_OK && strlen(hostBuffer) > 0) {
+        launcher_api_host = String(hostBuffer);
+    } else {
+        launcher_api_host = "launcherhub.svk.su";
+    }
     if (err != ESP_OK) {
         log_i("Failed to retrieve settings from NVS: %d\nUsing Default values", err);
         defaultValues();
@@ -853,6 +881,12 @@ void getConfigs() {
                 count++;
                 log_i("Fail");
             }
+            if (setting["api_host"].is<String>()) {
+                launcher_api_host = setting["api_host"].as<String>();
+            } else {
+                count++;
+                log_i("Fail");
+            }
             if (!setting["wifi"].is<JsonArray>()) {
                 ++count;
                 log_i("Fail");
@@ -952,6 +986,7 @@ void saveConfigs() {
         setting["wui_usr"] = wui_usr;
         setting["wui_pwd"] = wui_pwd;
         setting["dwn_path"] = dwn_path;
+        setting["api_host"] = launcher_api_host;
 
         File file = SDM.open(CONFIG_FILE, FILE_WRITE, true);
         if (!file) {

--- a/src/settings.h
+++ b/src/settings.h
@@ -31,6 +31,7 @@ config.conf JSON structure
 
 */
 void settings_menu();
+void setApiHost();
 void _setBrightness(uint8_t brightval) __attribute__((weak));
 void setBrightnessMenu();
 void setBrightness(int bright, bool save = true);


### PR DESCRIPTION
Introduce a configurable launcher API host and wire it through networking and settings. Added global variable launcher_api_host (declared in globals.h, initialized in main.cpp) and replaced hardcoded api.launcherhub.net URLs in onlineLauncher.cpp with dynamic use of launcher_api_host. Added UI to change the API host (setApiHost), persisted the value to NVS and the config JSON (saveIntoNVS/getFromNVS/getConfigs/saveConfigs), and exposed the prototype in settings.h. Defaults to "launcherhub.svk.su" and preserves backward compatibility when fid is empty. Note: merge conflict markers appear in onlineLauncher.cpp in this changeset and should be cleaned up.