### PR TITLE
Add Waveshare ESP32-S3-LCD-1.47 board support

### DIFF
--- a/boards/_jsonfiles/waveshare-esp32-s3-lcd-147.json
+++ b/boards/_jsonfiles/waveshare-esp32-s3-lcd-147.json
@@ -1,0 +1,48 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_opi",
+      "partitions": "default_16MB.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DWAVESHARE_ESP32_S3_LCD_147=1",
+      "-DARDUINO_USB_MODE=1",
+      "-DBOARD_HAS_PSRAM"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "pinouts"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3-builtin.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Waveshare ESP32-S3-LCD-1.47",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://www.waveshare.com/wiki/ESP32-S3-LCD-1.47",
+  "vendor": "Waveshare"
+}
+

--- a/boards/pinouts/pins_arduino.h
+++ b/boards/pinouts/pins_arduino.h
@@ -44,6 +44,8 @@
 #include "lilygo-t-display-s3-touch.h"
 #elif T_DONGLE_S3
 #include "lilygo-t-dongle-s3-tft.h"
+#elif WAVESHARE_ESP32_S3_LCD_147
+#include "waveshare-esp32-s3-lcd-147.h"
 #elif T_DISPLAY_S3_PRO
 #include "lilygo-t-display-s3-pro.h"
 #elif SMOOCHIEE_BOARD

--- a/boards/pinouts/waveshare-esp32-s3-lcd-147.h
+++ b/boards/pinouts/waveshare-esp32-s3-lcd-147.h
@@ -1,0 +1,78 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include "soc/soc_caps.h"
+#include <stdint.h>
+
+#define USB_VID 0x303A
+#define USB_PID 0x1001
+
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+static const uint8_t SDA = 1;
+static const uint8_t SCL = 2;
+
+static const uint8_t SS = 10;
+static const uint8_t MOSI = 11;
+static const uint8_t MISO = 12;
+static const uint8_t SCK = 13;
+
+static const uint8_t G0 = 0;
+static const uint8_t G1 = 1;
+static const uint8_t G2 = 2;
+static const uint8_t G3 = 3;
+static const uint8_t G4 = 4;
+static const uint8_t G5 = 5;
+static const uint8_t G6 = 6;
+static const uint8_t G7 = 7;
+static const uint8_t G8 = 8;
+static const uint8_t G9 = 9;
+static const uint8_t G10 = 10;
+static const uint8_t G11 = 11;
+static const uint8_t G12 = 12;
+static const uint8_t G13 = 13;
+static const uint8_t G14 = 14;
+static const uint8_t G15 = 15;
+static const uint8_t G39 = 39;
+static const uint8_t G40 = 40;
+static const uint8_t G41 = 41;
+static const uint8_t G42 = 42;
+static const uint8_t G43 = 43;
+static const uint8_t G44 = 44;
+static const uint8_t G45 = 45;
+static const uint8_t G48 = 48;
+
+#define GROVE_SDA 1
+#define GROVE_SCL 2
+
+#define RGB_LED 38
+
+#define HAS_SCREEN 1
+#define FP 1
+#define FM 2
+#define FG 3
+#define ROTATION 1
+#define MINBRIGHT 1
+
+#define ST7789_DRIVER 1
+#define TFT_WIDTH 172
+#define TFT_HEIGHT 320
+#define TFT_BACKLIGHT_ON HIGH
+#define TFT_BL 48
+#define TFT_RST 39
+#define TFT_DC 41
+#define TFT_MOSI 45
+#define TFT_SCLK 40
+#define TFT_CS 42
+
+#define PIN_SD_CLK 14
+#define PIN_SD_CMD 15
+#define PIN_SD_D0 16
+#define SDM SD_MMC
+#define SDCARD_CS -1
+#define SDCARD_SCK PIN_SD_CLK
+#define SDCARD_MISO PIN_SD_D0
+#define SDCARD_MOSI PIN_SD_CMD
+
+#endif /* Pins_Arduino_h */

--- a/boards/waveshare-esp32-s3-lcd-147/interface.cpp
+++ b/boards/waveshare-esp32-s3-lcd-147/interface.cpp
@@ -1,0 +1,120 @@
+#include "powerSave.h"
+#include <Arduino.h>
+#include <SD_MMC.h>
+#include <interface.h>
+
+/***************************************************************************************
+** Function name: _setup_gpio()
+** Location: main.cpp
+** Description:   initial setup for the device
+***************************************************************************************/
+void _setup_gpio() {
+#ifdef USE_SD_MMC
+    SD_MMC.setPins(PIN_SD_CLK, PIN_SD_CMD, PIN_SD_D0);
+#endif
+
+    pinMode(TFT_BL, OUTPUT);
+    digitalWrite(TFT_BL, HIGH);
+
+    pinMode(TFT_CS, OUTPUT);
+    digitalWrite(TFT_CS, HIGH);
+
+    pinMode(TFT_DC, OUTPUT);
+    digitalWrite(TFT_DC, HIGH);
+
+    pinMode(TFT_RST, OUTPUT);
+    digitalWrite(TFT_RST, HIGH);
+    delay(10);
+    digitalWrite(TFT_RST, LOW);
+    delay(20);
+    digitalWrite(TFT_RST, HIGH);
+    delay(120);
+
+    pinMode(SEL_BTN, INPUT_PULLUP);
+}
+
+/***************************************************************************************
+** Function name: _post_setup_gpio()
+** Location: main.cpp
+** Description:   second stage gpio setup to make a few functions work
+***************************************************************************************/
+void _post_setup_gpio() {}
+
+/***************************************************************************************
+** Function name: getBattery()
+** location: display.cpp
+** Description:   Delivers the battery value from 1-100
+***************************************************************************************/
+int getBattery() { return 0; }
+
+/*********************************************************************
+** Function: setBrightness
+** location: settings.cpp
+** set brightness value
+**********************************************************************/
+void _setBrightness(uint8_t brightval) {
+    if (brightval == 0) {
+        analogWrite(TFT_BL, 0);
+        return;
+    }
+
+    int bl = MINBRIGHT + round(((255 - MINBRIGHT) * brightval / 100.0));
+    analogWrite(TFT_BL, bl);
+}
+
+/*********************************************************************
+** Function: InputHandler
+** Handles the variables PrevPress, NextPress, SelPress, AnyKeyPress and EscPress
+**********************************************************************/
+void InputHandler(void) {
+    static unsigned long tm = 0;
+    constexpr unsigned long kInputDebounceMs = 75;
+    if (millis() - tm < kInputDebounceMs && !LongPress) return;
+
+    checkPowerSaveTime();
+
+    static bool buttonWasDown = false;
+    static unsigned long buttonDownAt = 0;
+    constexpr unsigned long kSelectPressMs = 550;
+    constexpr unsigned long kBackPressMs = 1200;
+
+    PrevPress = false;
+    NextPress = false;
+    SelPress = false;
+    EscPress = false;
+    AnyKeyPress = false;
+
+    bool buttonDown = (digitalRead(SEL_BTN) == BTN_ACT);
+
+    if (buttonDown && !buttonWasDown) {
+        buttonWasDown = true;
+        buttonDownAt = millis();
+        tm = millis();
+        AnyKeyPress = true;
+        LongPress = false;
+        if (wakeUpScreen()) return;
+    }
+
+    if (buttonDown) {
+        tm = millis();
+        AnyKeyPress = true;
+        if (millis() - buttonDownAt >= kSelectPressMs) {
+            LongPress = true;
+        }
+        return;
+    }
+
+    if (buttonWasDown) {
+        buttonWasDown = false;
+        unsigned long heldMs = millis() - buttonDownAt;
+        if (heldMs >= kBackPressMs) {
+            EscPress = true;
+        } else if (heldMs >= kSelectPressMs) {
+            SelPress = true;
+        } else {
+            NextPress = true;
+        }
+        AnyKeyPress = true;
+        LongPress = false;
+    }
+}

--- a/boards/waveshare-esp32-s3-lcd-147/platformio.ini
+++ b/boards/waveshare-esp32-s3-lcd-147/platformio.ini
@@ -25,12 +25,10 @@ build_flags =
 	-DFP=1
 	-DFM=2
 	-DFG=3
-	-DUSE_TFT_ESPI
 	-DST7789_DRIVER=1
 	-DUSER_SETUP_LOADED
 	-DTFT_RGB_ORDER=TFT_BGR
 	-DINIT_SEQUENCE_3
-	-DTFT_INVERSION_ON
 	-DCGRAM_OFFSET
 	-DTFT_WIDTH=172
 	-DTFT_HEIGHT=320
@@ -63,7 +61,4 @@ build_flags =
 
 lib_deps =
 	${env.lib_deps}
-	Bodmer/TFT_eSPI @ 2.5.43
 
-lib_ignore =
-	GFX Library for Arduino

--- a/boards/waveshare-esp32-s3-lcd-147/platformio.ini
+++ b/boards/waveshare-esp32-s3-lcd-147/platformio.ini
@@ -1,0 +1,69 @@
+[env:waveshare-esp32-s3-lcd-147]
+board = waveshare-esp32-s3-lcd-147
+board_build.partitions = support_files/custom_16Mb.csv
+build_src_filter = ${env.build_src_filter} +<../boards/waveshare-esp32-s3-lcd-147>
+build_flags =
+	${env.build_flags}
+	-Iboards/waveshare-esp32-s3-lcd-147
+	-DDISABLE_OTA
+	-DBOARD_HAS_PSRAM=1
+	-DARDUINO_USB_CDC_ON_BOOT=1
+	-DARDUINO_USB_MODE=1
+	-DWAVESHARE_ESP32_S3_LCD_147=1
+	-DPART_16MB=1
+	-DROTATION=1
+	-DHAS_BTN=1
+	-DSEL_BTN=0
+	-DUP_BTN=-1
+	-DDW_BTN=-1
+	-DBTN_ACT=LOW
+	-DBTN_ALIAS='"OK"'
+	-DMINBRIGHT=1
+	-DBACKLIGHT=48
+	-DLED=38
+	-DLED_ON=HIGH
+	-DFP=1
+	-DFM=2
+	-DFG=3
+	-DUSE_TFT_ESPI
+	-DST7789_DRIVER=1
+	-DUSER_SETUP_LOADED
+	-DTFT_RGB_ORDER=TFT_BGR
+	-DINIT_SEQUENCE_3
+	-DTFT_INVERSION_ON
+	-DCGRAM_OFFSET
+	-DTFT_WIDTH=172
+	-DTFT_HEIGHT=320
+	-DTFT_MISO=-1
+	-DTFT_MOSI=45
+	-DTFT_SCLK=40
+	-DTFT_CS=42
+	-DTFT_DC=41
+	-DTFT_RST=39
+	-DTFT_BL=48
+	-DTFT_BACKLIGHT_ON=HIGH
+	-DGFX_BL=48
+	-DTFT_IPS=1
+	-DTFT_COL_OFS1=34
+	-DTFT_ROW_OFS1=0
+	-DTFT_COL_OFS2=34
+	-DTFT_ROW_OFS2=0
+	-DSPI_FREQUENCY=40000000
+	-DSPI_READ_FREQUENCY=20000000
+	-DUSE_HSPI_PORT=1
+	-DLOAD_GLCD=1
+	-DLOAD_FONT2=1
+	-DLOAD_FONT4=1
+	-DLOAD_FONT6=1
+	-DLOAD_FONT7=1
+	-DUSE_SD_MMC=1
+	-DPIN_SD_CLK=14
+	-DPIN_SD_CMD=15
+	-DPIN_SD_D0=16
+
+lib_deps =
+	${env.lib_deps}
+	Bodmer/TFT_eSPI @ 2.5.43
+
+lib_ignore =
+	GFX Library for Arduino

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -296,8 +296,6 @@ void setup() {
 
 #endif
     tft->setRotation(rotation);
-    tft->setTextFont(1);
-    tft->setTextWrap(false);
     tft->setTextColor(FGCOLOR, BGCOLOR);
     if (rotation & 0b1) {
 #if defined(HAS_TOUCH)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -296,6 +296,9 @@ void setup() {
 
 #endif
     tft->setRotation(rotation);
+    tft->setTextFont(1);
+    tft->setTextWrap(false);
+    tft->setTextColor(FGCOLOR, BGCOLOR);
     if (rotation & 0b1) {
 #if defined(HAS_TOUCH)
         tftHeight = TFT_WIDTH - (FM * LH + 4);
@@ -372,7 +375,11 @@ void setup() {
         }
 #endif
         // Direct input check for startup - bypass check() function to avoid task suspension
+#if defined(WAVESHARE_ESP32_S3_LCD_147)
+        if (check(SelPress) || check(NextPress) || check(EscPress) || check(AnyKeyPress)) {
+#else
         if (check(SelPress)) {
+#endif
             tft->fillScreen(BGCOLOR);
             goto Launcher;
         }
@@ -380,6 +387,8 @@ void setup() {
 #if defined(HAS_KEYBOARD)
         keyStroke key = _getKeyPress();
         if (key.pressed && !key.enter)
+#elif defined(WAVESHARE_ESP32_S3_LCD_147)
+        if (false)
 #elif defined(STICK_C_PLUS2) || defined(STICK_C_PLUS)
         if (NextPress)
 #else

--- a/src/mykeyboard.cpp
+++ b/src/mykeyboard.cpp
@@ -227,6 +227,9 @@ String generalKeyboard(
     bool selection_made = false; // used for detecting if an key or a button was selected
     bool redraw = true;
     long last_input_time = millis(); // used for input debouncing
+    unsigned long pending_next_at = 0;
+    bool pending_next = false;
+    constexpr unsigned long kDoubleTapWindowMs = 275;
     // cursor coordinates: kep track of where the next character should be printed (in screen pixels)
     int cursor_x = 0;
     int cursor_y = 0;
@@ -581,7 +584,72 @@ String generalKeyboard(
             }
 #endif
 
-#if defined(HAS_3_BUTTONS) // StickCs and Core
+#if defined(WAVESHARE_ESP32_S3_LCD_147)
+            auto moveKeyboardCursorNext = [&]() {
+                if (y < 0) {
+                    x++;
+                    if (x >= buttons_number) {
+                        y = 0;
+                        x = 0;
+                    }
+                } else {
+                    x++;
+                    if (x >= KeyboardWidth) {
+                        x = 0;
+                        y++;
+                    }
+                    if (y >= KeyboardHeight) { y = -1; }
+                }
+                redraw = true;
+            };
+
+            auto moveKeyboardCursorPrev = [&]() {
+                if (y < 0) {
+                    x--;
+                    if (x < 0) {
+                        y = KeyboardHeight - 1;
+                        x = KeyboardWidth - 1;
+                    }
+                } else {
+                    x--;
+                    if (x < 0) {
+                        y--;
+                        if (y < 0) {
+                            y = -1;
+                            x = buttons_number - 1;
+                        } else {
+                            x = KeyboardWidth - 1;
+                        }
+                    }
+                }
+                redraw = true;
+            };
+
+            if (pending_next && millis() - pending_next_at > kDoubleTapWindowMs) {
+                pending_next = false;
+                moveKeyboardCursorNext();
+                last_input_time = millis();
+            }
+
+            if (check(EscPress)) {
+                pending_next = false;
+                current_text = KEY_ESCAPE;
+                break;
+            }
+            if (check(SelPress)) {
+                pending_next = false;
+                selection_made = true;
+            } else if (check(NextPress)) {
+                if (pending_next && millis() - pending_next_at <= kDoubleTapWindowMs) {
+                    pending_next = false;
+                    moveKeyboardCursorPrev();
+                    last_input_time = millis();
+                } else {
+                    pending_next = true;
+                    pending_next_at = millis();
+                }
+            }
+#elif defined(HAS_3_BUTTONS) // StickCs and Core
             if (check(SelPress)) {
                 selection_made = true;
             } else {

--- a/src/onlineLauncher.cpp
+++ b/src/onlineLauncher.cpp
@@ -81,9 +81,11 @@ void wifiConnect(String ssid, int encryptation, bool isAP) {
         }
     } else { // Running in Access point mode
         IPAddress AP_GATEWAY(172, 0, 0, 1);
+#if !CONFIG_ESP_HOSTED_ENABLED
         WiFi.softAPdisconnect(true);
         WiFi.disconnect(true, true);
         vTaskDelay(50 / portTICK_PERIOD_MS);
+#endif
         WiFi.mode(WIFI_AP);
         WiFi.setSleep(false);
         WiFi.softAPConfig(AP_GATEWAY, AP_GATEWAY, IPAddress(255, 255, 255, 0));

--- a/src/onlineLauncher.cpp
+++ b/src/onlineLauncher.cpp
@@ -52,6 +52,8 @@ void wifiConnect(String ssid, int encryptation, bool isAP) {
             }
         }
 
+        WiFi.mode(WIFI_STA);
+        WiFi.setSleep(false);
         WiFi.begin(ssid.c_str(), pwd.c_str());
 
         resetTftDisplay(10, 10, FGCOLOR, FP);
@@ -79,9 +81,14 @@ void wifiConnect(String ssid, int encryptation, bool isAP) {
         }
     } else { // Running in Access point mode
         IPAddress AP_GATEWAY(172, 0, 0, 1);
+        WiFi.softAPdisconnect(true);
+        WiFi.disconnect(true, true);
+        vTaskDelay(50 / portTICK_PERIOD_MS);
         WiFi.mode(WIFI_AP);
+        WiFi.setSleep(false);
         WiFi.softAPConfig(AP_GATEWAY, AP_GATEWAY, IPAddress(255, 255, 255, 0));
-        WiFi.softAP("Launcher", "", 6, 0, 1, false);
+        WiFi.softAP("Launcher", "", 6, 0, 4, false);
+        vTaskDelay(250 / portTICK_PERIOD_MS);
         Serial.print("IP: ");
         Serial.println(WiFi.softAPIP());
     }

--- a/src/sd_functions.cpp
+++ b/src/sd_functions.cpp
@@ -74,8 +74,19 @@ Exit:
 ** Description:   Start SD Card
 ***************************************************************************************/
 bool setupSdCard() {
-#if !defined(SDM_SD)                    // fot Lilygo T-Display S3 with lilygo shield
-    if (!SD_MMC.begin("/sdcard", true)) // One bit mode
+#if !defined(SDM_SD) // fot Lilygo T-Display S3 with lilygo shield
+#if defined(USE_SD_MMC) && defined(PIN_SD_CLK) && defined(PIN_SD_CMD) && defined(PIN_SD_D0)
+    SD_MMC.end();
+    vTaskDelay(pdTICKS_TO_MS(20));
+    SD_MMC.setPins(PIN_SD_CLK, PIN_SD_CMD, PIN_SD_D0);
+    vTaskDelay(pdTICKS_TO_MS(10));
+    if (!SD_MMC.begin("/sdcard", true, false)) // One bit mode, don't auto-format
+#else
+#if defined(USE_SD_MMC) && defined(PIN_SD_CLK) && defined(PIN_SD_CMD) && defined(PIN_SD_D0)
+    vTaskDelay(pdTICKS_TO_MS(10));
+#endif
+    if (!SD_MMC.begin("/sdcard", true, false)) // One bit mode, don't auto-format
+#endif
 #elif (TFT_MOSI == SDCARD_MOSI)
     if (!SDM.begin(_cs)) // https://github.com/Bodmer/TFT_eSPI/discussions/2420
 #elif defined(HEADLESS)

--- a/src/sd_functions.cpp
+++ b/src/sd_functions.cpp
@@ -80,13 +80,9 @@ bool setupSdCard() {
     vTaskDelay(pdTICKS_TO_MS(20));
     SD_MMC.setPins(PIN_SD_CLK, PIN_SD_CMD, PIN_SD_D0);
     vTaskDelay(pdTICKS_TO_MS(10));
-    if (!SD_MMC.begin("/sdcard", true, false)) // One bit mode, don't auto-format
 #else
-#if defined(USE_SD_MMC) && defined(PIN_SD_CLK) && defined(PIN_SD_CMD) && defined(PIN_SD_D0)
-    vTaskDelay(pdTICKS_TO_MS(10));
 #endif
     if (!SD_MMC.begin("/sdcard", true, false)) // One bit mode, don't auto-format
-#endif
 #elif (TFT_MOSI == SDCARD_MOSI)
     if (!SDM.begin(_cs)) // https://github.com/Bodmer/TFT_eSPI/discussions/2420
 #elif defined(HEADLESS)

--- a/src/webInterface.cpp
+++ b/src/webInterface.cpp
@@ -286,8 +286,14 @@ void configureWebServer() {
 
     // configure web server
 
-    MDNS.begin(host);
+    if (MDNS.begin(host)) {
+        MDNS.addService("http", "tcp", config.webserverporthttp);
+    }
     DefaultHeaders::Instance().addHeader("Access-Control-Allow-Origin", "*");
+    server->on("/ping", HTTP_GET, [](AsyncWebServerRequest *request) {
+        Serial.println("WebUI /ping");
+        request->send(200, "text/plain", "launcher-pong");
+    });
     // if url isn't found
     server->onNotFound([](AsyncWebServerRequest *request) { request->redirect("/"); });
 
@@ -609,6 +615,7 @@ void startWebUi(String ssid, int encryptation, bool mode_ap) {
         // Choose wifi access mode
         wifiConnect(ssid, encryptation, mode_ap);
     }
+    vTaskDelay(pdMS_TO_TICKS(250));
 
     // configure web server
     // log_i("Configuring WebServer");


### PR DESCRIPTION
## Summary
Adds support for the Waveshare ESP32-S3-LCD-1.47 board.

## What changed
- added a new `waveshare-esp32-s3-lcd-147` board target
- added board pinout/header wiring for this device
- fixed display init and text rendering for the 172x320 ST7789 panel
- added Waveshare-specific single-button navigation handling
- added keyboard double-tap previous behavior for the one-button layout
- fixed SD card access on this board by using `SD_MMC`
- improved WebUI startup / AP behavior for this board

## Button behavior
- single tap = next
- medium hold = select
- long hold = back
- keyboard double tap = previous

## Tested
- Launcher boots and renders correctly
- text renders correctly
- SD card mounts and is usable
- firmware install from SD works
- WebUI works in AP mode and on local network
- single-button navigation works for menu flow and keyboard

## Notes
This board uses a one-button interaction model, so the navigation changes are scoped to the Waveshare target.
