### PR TITLE
fix: div-by-zero in pasteFile() and wrong partition offset byte order

### DIFF
--- a/src/partitioner.cpp
+++ b/src/partitioner.cpp
@@ -959,8 +959,11 @@ bool attachPartition(String _from, String _to) {
             to.read(bytes, 16);
 
             if (bytes[3] == 0x81 || bytes[3] == 0x82 || bytes[3] == 0x83) {
-                // Calculate offset (big endian)
-                offset = (bytes[0x06] << 16) | (bytes[0x07] << 8) | bytes[0x08];
+                // Offset is a uint32 at bytes 4-7, little-endian (ESP-IDF partition table format)
+                offset = (uint32_t)bytes[0x04]
+                       | ((uint32_t)bytes[0x05] << 8)
+                       | ((uint32_t)bytes[0x06] << 16)
+                       | ((uint32_t)bytes[0x07] << 24);
                 launcherConsolePrintf("offset=%d\n", offset);
             }
         }

--- a/src/sd_functions.cpp
+++ b/src/sd_functions.cpp
@@ -182,7 +182,7 @@ bool pasteFile(String path) {
             return false;
         } else {
             prog += bytesRead;
-            float rad = 360 * prog / tot;
+            float rad = (tot > 0) ? (360.0f * prog / tot) : 0.0f;
             tft->drawArc(tftWidth / 2, tftHeight / 2, tftHeight / 4, tftHeight / 5, 0, int(rad), ALCOLOR);
             // tft->fillRect(7,tftHeight-10, (tftWidth-14)*prog/tot, 5, FGCOLOR);
         }


### PR DESCRIPTION
## Summary

- **`src/sd_functions.cpp` `pasteFile()`:** `360 * prog / tot` divides by zero when `sourceFile.size()` returns 0 (can happen on some FAT implementations before the SD entry flushes, or for a genuinely empty file). Guarded with `(tot > 0) ? ... : 0.0f`.

- **`src/partitioner.cpp` `attachPartition()`:** The partition offset was read as three bytes starting at position 6, interpreted as big-endian. The ESP-IDF partition table stores the offset as a uint32_t at bytes 4-7 in little-endian order. The previous code skipped bytes 4-5 entirely and read bytes 6-8 big-endian, producing a completely wrong offset. Any firmware flash path exercising attachPartition() would write to the wrong flash address.

## Test plan

- [ ] Copy a non-empty file via the file manager — progress arc draws correctly
- [ ] Copy a zero-byte file — no crash, arc stays at 0
- [ ] Flash a firmware .bin via the partition installer — offset in log matches expected value from gen_esp32part.py output for the target board

Generated with Claude Code