### PR TITLE
fix: malformed default config JSON and spurious NVS settings reset on OTA upgrade

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -482,7 +482,7 @@ bool config_exists() {
             conf.printf(
                 "[{\"%s\":%d,\"dimmerSet\":10,\"onlyBins\":1,\"bootToApp\":1,\"noDotFiles\":1,\"bright\":100,"
                 "\"askSpiffs\":1,\"wui_usr\":\"admin\",\"wui_pwd\":\"launcher\",\"dwn_path\":\"/downloads/"
-                "\",\"FGCOLOR\":2016,\"BGCOLOR\":0,\"ALCOLOR\":63488,\"even\":13029,\"odd\":12485,\",\"dev\":"
+                "\",\"FGCOLOR\":2016,\"BGCOLOR\":0,\"ALCOLOR\":63488,\"even\":13029,\"odd\":12485,\"dev\":"
                 "0,\"wifi\":[{\"ssid\":\"myNetSSID\",\"pwd\":\"myNetPassword\"}], \"favorite\":[]}]",
                 get_efuse_mac_as_string().c_str(),
                 ROTATION
@@ -684,7 +684,9 @@ bool getFromNVS() {
     if (lastAppErr == ESP_OK) lastInstalledApp = String(appBuffer);
     else if (lastAppErr == ESP_ERR_NVS_NOT_FOUND) lastInstalledApp = "";
     else err |= lastAppErr;
-    if (err != ESP_OK) {
+    // ESP_ERR_NVS_NOT_FOUND is expected after a firmware update adds new settings keys
+    // that haven't been written yet. Keep values at their defaults instead of wiping everything.
+    if (err != ESP_OK && err != ESP_ERR_NVS_NOT_FOUND) {
         log_i("Failed to retrieve settings from NVS: %d\nUsing Default values", err);
         defaultValues();
         return false;


### PR DESCRIPTION
## Summary

- **`src/settings.cpp` `config_exists()`:** The default config template had a stray backslash-quote before the `"dev"` key, producing `,"` in the serialised JSON (`odd":12485,","dev":0`). ArduinoJson rejected this on first read, leaving the device with no persisted config until a manual file delete.

- **`src/settings.cpp` `getSettingsNVS()`:** NVS reads were accumulated with `|=`, so `ESP_ERR_NVS_NOT_FOUND` from any unwritten key (e.g. a new setting added by a firmware update) triggered a full reset to defaults, silently discarding all user configuration on every OTA upgrade. The check now only resets on genuine I/O errors; `NOT_FOUND` is treated as "use default for this key" — the same pattern already used for the `last_app` key a few lines below.

## Test plan

- [ ] Delete `config.conf` from SD, reboot — new file is created and parses without error
- [ ] Flash a build that adds a new NVS key, then OTA-upgrade to it — existing settings survive, new key gets its default value
- [ ] Genuine NVS read failure (corrupt partition) still resets to defaults

Generated with Claude Code