### PR TITLE
fix(cardputer-adv): three TCA8418 keyboard bugs — phantom interrupt, sel/esc cleared by up/down, multi-key wake

### DIFF
--- a/boards/m5stack-cardputer/interface.cpp
+++ b/boards/m5stack-cardputer/interface.cpp
@@ -129,7 +129,10 @@ void _post_setup_gpio() {
     tca.matrix(7, 8);
     tca.flush();
     launcherGpioInput(11);
-    attachInterruptArg(digitalPinToInterrupt(11), gpio_isr_handler, nullptr, CHANGE);
+    // TCA8418 INT is active-low; only the falling edge means "event available".
+    // FALLING avoids the spurious rising-edge ISR that fired after we cleared
+    // INT_STAT, which was resetting the sel/esc hold state one frame too early.
+    attachInterruptArg(digitalPinToInterrupt(11), gpio_isr_handler, nullptr, FALLING);
     tca.enableInterrupts();
 }
 
@@ -188,6 +191,7 @@ void InputHandler(void) {
         if (kb_interrupt) {
             // Drain the FIFO now. Processing one TCA8418 event per 200 ms made quick taps
             // pile up and replay later as delayed navigation.
+            bool wokeScreen = false;
             while (tca.available() > 0) {
                 int keyEvent = tca.getEvent();
                 bool pressed = (keyEvent & 0x80); // Bit 7: 1 Pressed, 0 Released
@@ -202,7 +206,11 @@ void InputHandler(void) {
 
                 if (row >= 4 || col >= 14) continue;
 
-                if (wakeUpScreen()) continue;
+                // wakeUpScreen() is stateful — it returns true only on the first call when
+                // the screen is actually sleeping. Track the result so that all remaining
+                // events in the same FIFO burst are also discarded, not just the first one.
+                if (!wokeScreen) wokeScreen = wakeUpScreen();
+                if (wokeScreen) continue;
 
                 AnyKeyPress = true;
                 keyEventHandled = true;
@@ -329,7 +337,7 @@ void InputHandler(void) {
             downRepeatTime = now + TCA8418_REPEAT_MS;
         }
 
-        if (!keyEventHandled && !nextPulse && !prevPulse && !LongPress) {
+        if (!keyEventHandled && !nextPulse && !prevPulse && !upPulse && !downPulse && !LongPress) {
             sel = false; // avoid multiple selections
             esc = false; // avoid multiple escapes
         }


### PR DESCRIPTION
## Summary

Three bugs in the Cardputer ADV TCA8418 keyboard handler (`boards/m5stack-cardputer/interface.cpp`):

**1. CHANGE -> FALLING interrupt**
The TCA8418 INT line is active-low. `CHANGE` fired the ISR on both edges — including the rising edge when we cleared `INT_STAT`, producing a spurious `kb_interrupt=true` with an empty FIFO. The next InputHandler call found nothing to process but still hit the `!keyEventHandled` guard and reset the `sel`/`esc` hold state one frame too early. Enter and Esc presses appeared momentary even while the key was still held. `FALLING` fires only when a new event is available.

**2. `sel`/`esc` cleared during up/down repeat**
The `!nextPulse && !prevPulse` guard was supposed to protect `sel` and `esc` from being cleared during directional repeats, but `upPulse` and `downPulse` were missing from the condition. Pressing Up or Down while Enter was held (e.g. scrolling through a long press menu) would silently cancel the selection.

**3. Multiple keys processed on screen wake**
`wakeUpScreen()` is stateful — it returns `true` only on the first call when the screen is actually sleeping. Without tracking the result, only the first FIFO event was discarded; subsequent events in the same burst were processed normally, causing unintended navigation immediately after the screen came on. A `wokeScreen` flag now discards all events from the burst that woke the screen.

## Test plan

- [ ] Hold Enter — confirm it stays selected across multiple frames without spurious release
- [ ] Hold Enter, press Down — confirm Enter hold is preserved
- [ ] Let screen dim, press a key to wake — confirm no menu navigation fires on wake
- [ ] Normal key repeat (hold `/` or `.`) — confirm still works

Generated with Claude Code