### PR TITLE
fix: support arbitrary partition labels for SPIFFS/LittleFS data partitions

### DIFF
--- a/src/onlineLauncher.cpp
+++ b/src/onlineLauncher.cpp
@@ -386,7 +386,8 @@ bool flashRawRangeFromHttp(
 bool installFirmwareDynamic(
     const String &fileAddr, const String &file, uint32_t appSize, uint32_t appPartitionSize,
     uint32_t appOffset, bool spiffs, uint32_t spiffsOffset, uint32_t spiffsSize, uint32_t spiffsCopySize,
-    bool nb, std::vector<LauncherInstallFatPartition> &fatPartitions, const String &installedName
+    bool nb, std::vector<LauncherInstallFatPartition> &fatPartitions, const String &installedName,
+    const String &spiffsLabel
 ) {
     String error;
     LauncherPartitionTable table;
@@ -440,7 +441,8 @@ bool installFirmwareDynamic(
             appEntry,
             spiffsEntry,
             hasSpiffsEntry,
-            error
+            error,
+            spiffsLabel
         )) {
         displayRedStripe(error.length() ? error : "No install space");
         launcherDelayMs(2000);
@@ -659,6 +661,7 @@ void installFirmwareFromManifest(String fid, String version, String installedNam
     uint32_t spiffsOffset = 0;
     uint32_t spiffsSize = 0;
     uint32_t spiffsCopySize = 0;
+    String spiffsLabel = "spiffs";
 
     std::vector<LauncherInstallFatPartition> fatPartitions;
 
@@ -670,7 +673,7 @@ void installFirmwareFromManifest(String fid, String version, String installedNam
             appCopySize = part["copy_size"] | appCopySize;
             appPartitionSize = appCopySize;
             nb = appOffset == 0;
-        } else if (type == "data" && subtype == "spiffs") {
+        } else if (type == "data" && (subtype == "spiffs" || subtype == "littlefs")) {
             spiffs = true;
             uint32_t declaredSize = part["size"] | 0;
             spiffsOffset = part["source_offset"] | 0;
@@ -678,6 +681,8 @@ void installFirmwareFromManifest(String fid, String version, String installedNam
             spiffsSize = declaredSize > LAUNCHER_DEFAULT_SPIFFS_THRESHOLD
                              ? LAUNCHER_INSTALL_USE_REMAINING_SPIFFS_SIZE
                              : LAUNCHER_DEFAULT_SPIFFS_SIZE;
+            String declaredLabel = part["label"].as<String>();
+            if (!declaredLabel.isEmpty()) spiffsLabel = declaredLabel;
         } else if (type == "data" && subtype == "fat") {
             LauncherInstallFatPartition fatPartition;
             fatPartition.label = part["label"].as<String>();
@@ -718,7 +723,8 @@ void installFirmwareFromManifest(String fid, String version, String installedNam
             spiffsCopySize,
             nb,
             fatPartitions,
-            installedName
+            installedName,
+            spiffsLabel
         )) {
         launcherDelayMs(2500);
     }
@@ -804,9 +810,10 @@ bool installExtFirmware(String url) {
     bool spiffs = 0;
     uint32_t spiffs_offset = 0;
     uint32_t spiffs_size = 0;
+    String spiffsLabel = "spiffs";
     bool nb = 1;
     std::vector<LauncherInstallFatPartition> fatPartitions;
-    uint8_t bytes[16];
+    uint8_t bytes[32];
     if (!url.startsWith("https://")) {
         displayRedStripe("Invalid link");
         launcherDelayMs(2000);
@@ -828,7 +835,7 @@ bool installExtFirmware(String url) {
     if (buff[0] == 0xAA) {
         nb = 0;
         for (int i = 0x0; i <= 0x1A0; i += 0x20) {
-            memcpy(bytes, &buff[i], 16);
+            memcpy(bytes, &buff[i], 32);
 
             if (bytes[3] == 0x00 || (bytes[3] >= 0x10 && bytes[3] <= 0x1F)) {
                 if (bytes[0x0A] > 0 && PartitionSize == 0) {
@@ -855,6 +862,13 @@ bool installExtFirmware(String url) {
                 spiffs_offset = (bytes[0x06] << 16) | (bytes[0x07] << 8) | bytes[0x08];
                 bytes[0x0C] = 0;
                 spiffs_size = (bytes[0x0A] << 16) | (bytes[0x0B] << 8) | bytes[0x0C];
+                // Read the actual partition label from the table entry
+                char labelBuf[17] = {0};
+                memcpy(labelBuf, bytes + 12, 16);
+                labelBuf[16] = '\0';
+                if (labelBuf[0] != '\0') {
+                    spiffsLabel = String(labelBuf);
+                }
             }
         }
         size_t temp_size = 0;
@@ -882,7 +896,8 @@ bool installExtFirmware(String url) {
         spiffs_size,
         nb,
         fatPartitions,
-        "External OTA"
+        "External OTA",
+        spiffsLabel
     );
     return true;
 }
@@ -893,7 +908,7 @@ bool installExtFirmware(String url) {
 ***************************************************************************************/
 void installFirmware( // adicionar "fid"
     String fid, String file, uint32_t app_size, uint32_t app_offset, bool spiffs, uint32_t spiffs_offset, uint32_t spiffs_size, bool nb,
-    std::vector<LauncherInstallFatPartition> &fatPartitions, String installedName
+    std::vector<LauncherInstallFatPartition> &fatPartitions, String installedName, const String &spiffsLabel
 ) {
     if (!file.startsWith("https://")) file = M5_SERVER_PATH + file;
     String fileAddr = "https://api.launcherhub.net/download?fid=" + fid + "&file=" + file;
@@ -932,7 +947,8 @@ void installFirmware( // adicionar "fid"
             spiffsCopySize,
             nb,
             fatPartitions,
-            installedName
+            installedName,
+            spiffsLabel
         )) {
         launcherDelayMs(2500);
     }

--- a/src/onlineLauncher.h
+++ b/src/onlineLauncher.h
@@ -10,7 +10,7 @@ bool installExtFirmware(String url);
 void installFirmware(
     String fid, String file, uint32_t app_size, uint32_t app_offset, bool spiffs, uint32_t spiffs_offset,
     uint32_t spiffs_size, bool nb, std::vector<LauncherInstallFatPartition> &fatPartitions,
-    String installedName = ""
+    String installedName = "", const String &spiffsLabel = "spiffs"
 );
 void installFirmwareFromManifest(String fid, String version, String installedName = "");
 

--- a/src/partition_install_layout.cpp
+++ b/src/partition_install_layout.cpp
@@ -6,7 +6,8 @@
 
 bool launcherPrepareInstallDataPartitions(
     LauncherPartitionTable &table, bool spiffs, uint32_t spiffsSize, LauncherPartitionEntry &spiffsEntry,
-    bool &hasSpiffsEntry, std::vector<LauncherInstallFatPartition> &fatPartitions, String &error
+    bool &hasSpiffsEntry, std::vector<LauncherInstallFatPartition> &fatPartitions, String &error,
+    const String &spiffsLabel
 ) {
     hasSpiffsEntry = false;
     for (LauncherInstallFatPartition &fatPartition : fatPartitions) {
@@ -15,32 +16,32 @@ bool launcherPrepareInstallDataPartitions(
     }
 
     auto prepareSpiffs = [&]() {
-        LauncherPartitionEntry *existing = launcherPartitionFindByLabel(table, "spiffs");
+        LauncherPartitionEntry *existing = launcherPartitionFindByLabel(table, spiffsLabel.c_str());
         if (existing) {
             if (!existing->isData() || existing->subtype != 0x82) {
-                error = "Partition spiffs is incompatible";
+                error = String("Partition ") + spiffsLabel + " is incompatible";
                 return false;
             }
             if (spiffsSize == LAUNCHER_INSTALL_USE_REMAINING_SPIFFS_SIZE) {
                 uint32_t oldOffset = existing->offset;
                 if (!launcherPartitionRemoveEntryByOffset(table, oldOffset)) {
-                    error = "Could not resize spiffs partition";
+                    error = String("Could not resize ") + spiffsLabel + " partition";
                     return false;
                 }
-                if (!launcherPartitionCreateDataInLargestFreeRange(table, 0x82, "spiffs", spiffsEntry, error))
+                if (!launcherPartitionCreateDataInLargestFreeRange(table, 0x82, spiffsLabel.c_str(), spiffsEntry, error))
                     return false;
                 return true;
             }
             if (spiffsSize != LAUNCHER_INSTALL_USE_REMAINING_SPIFFS_SIZE && existing->size < spiffsSize) {
-                error = "Partition spiffs is too small or incompatible";
+                error = String("Partition ") + spiffsLabel + " is too small or incompatible";
                 return false;
             }
             spiffsEntry = *existing;
         } else if (spiffsSize == LAUNCHER_INSTALL_USE_REMAINING_SPIFFS_SIZE) {
-            if (!launcherPartitionCreateDataInLargestFreeRange(table, 0x82, "spiffs", spiffsEntry, error))
+            if (!launcherPartitionCreateDataInLargestFreeRange(table, 0x82, spiffsLabel.c_str(), spiffsEntry, error))
                 return false;
         } else {
-            if (!launcherPartitionFindOrCreateData(table, 0x82, "spiffs", spiffsSize, spiffsEntry, error))
+            if (!launcherPartitionFindOrCreateData(table, 0x82, spiffsLabel.c_str(), spiffsSize, spiffsEntry, error))
                 return false;
         }
         hasSpiffsEntry = true;
@@ -72,7 +73,8 @@ bool launcherPrepareInstallDataPartitions(
 bool launcherSelectInstallLayout(
     LauncherPartitionTable &table, size_t updateSize, const String &defaultLabel, bool spiffs,
     uint32_t spiffsSize, std::vector<LauncherInstallFatPartition> &fatPartitions,
-    LauncherPartitionEntry &appEntry, LauncherPartitionEntry &spiffsEntry, bool &hasSpiffsEntry, String &error
+    LauncherPartitionEntry &appEntry, LauncherPartitionEntry &spiffsEntry, bool &hasSpiffsEntry, String &error,
+    const String &spiffsLabel
 ) {
     const uint32_t requiredAppPartitionSize =
         launcherAlignUp(static_cast<uint32_t>(updateSize), LAUNCHER_APP_PARTITION_ALIGNMENT);
@@ -97,7 +99,7 @@ bool launcherSelectInstallLayout(
             directCandidate, updateSize, defaultLabel.c_str(), &directApp, &error
         ) &&
         launcherPrepareInstallDataPartitions(
-            directCandidate, spiffs, spiffsSize, directSpiffs, directHasSpiffs, directFats, error
+            directCandidate, spiffs, spiffsSize, directSpiffs, directHasSpiffs, directFats, error, spiffsLabel
         ) &&
         launcherPartitionValidate(directCandidate, &error)) {
         table = directCandidate;
@@ -114,7 +116,7 @@ bool launcherSelectInstallLayout(
     directFats = fatPartitions;
     directHasSpiffs = false;
     if (launcherPrepareInstallDataPartitions(
-            directCandidate, spiffs, spiffsSize, directSpiffs, directHasSpiffs, directFats, error
+            directCandidate, spiffs, spiffsSize, directSpiffs, directHasSpiffs, directFats, error, spiffsLabel
         ) &&
         launcherPartitionCreateOtaApp(
             directCandidate, updateSize, defaultLabel.c_str(), &directApp, &error
@@ -143,7 +145,7 @@ bool launcherSelectInstallLayout(
                     directCandidate, updateSize, defaultLabel.c_str(), &directApp, &error
                 ) &&
                 launcherPrepareInstallDataPartitions(
-                    directCandidate, spiffs, spiffsSize, directSpiffs, directHasSpiffs, directFats, error
+                    directCandidate, spiffs, spiffsSize, directSpiffs, directHasSpiffs, directFats, error, spiffsLabel
                 ) &&
                 launcherPartitionValidate(directCandidate, &error)) {
                 table = directCandidate;
@@ -205,7 +207,7 @@ bool launcherSelectInstallLayout(
             return;
         }
         if (!launcherPrepareInstallDataPartitions(
-                candidate, spiffs, spiffsSize, candidateSpiffs, candidateHasSpiffs, candidateFats, error
+                candidate, spiffs, spiffsSize, candidateSpiffs, candidateHasSpiffs, candidateFats, error, spiffsLabel
             ) ||
             !launcherPartitionValidate(candidate, &error)) {
             return;
@@ -225,7 +227,7 @@ bool launcherSelectInstallLayout(
         std::vector<LauncherInstallFatPartition> candidateFats = fatPartitions;
         bool candidateHasSpiffs = false;
         if (launcherPrepareInstallDataPartitions(
-                candidate, spiffs, spiffsSize, candidateSpiffs, candidateHasSpiffs, candidateFats, error
+                candidate, spiffs, spiffsSize, candidateSpiffs, candidateHasSpiffs, candidateFats, error, spiffsLabel
             ) &&
             launcherPartitionValidate(candidate, &error)) {
             addChoice(
@@ -291,7 +293,7 @@ bool launcherSelectInstallLayout(
         std::vector<LauncherInstallFatPartition> candidateFats = fatPartitions;
         bool candidateHasSpiffs = false;
         if (launcherPrepareInstallDataPartitions(
-                candidate, spiffs, spiffsSize, candidateSpiffs, candidateHasSpiffs, candidateFats, error
+                candidate, spiffs, spiffsSize, candidateSpiffs, candidateHasSpiffs, candidateFats, error, spiffsLabel
             ) &&
             launcherPartitionValidate(candidate, &error)) {
             addChoice(
@@ -324,7 +326,7 @@ bool launcherSelectInstallLayout(
             std::vector<LauncherInstallFatPartition> candidateFats = fatPartitions;
             bool candidateHasSpiffs = false;
             if (!launcherPrepareInstallDataPartitions(
-                    candidate, spiffs, spiffsSize, candidateSpiffs, candidateHasSpiffs, candidateFats, error
+                    candidate, spiffs, spiffsSize, candidateSpiffs, candidateHasSpiffs, candidateFats, error, spiffsLabel
                 ) ||
                 !launcherPartitionValidate(candidate, &error)) {
                 continue;
@@ -394,7 +396,7 @@ bool launcherSelectInstallLayout(
             std::vector<LauncherInstallFatPartition> candidateFats = fatPartitions;
             bool candidateHasSpiffs = false;
             if (!launcherPrepareInstallDataPartitions(
-                    candidate, spiffs, spiffsSize, candidateSpiffs, candidateHasSpiffs, candidateFats, error
+                    candidate, spiffs, spiffsSize, candidateSpiffs, candidateHasSpiffs, candidateFats, error, spiffsLabel
                 ) ||
                 !launcherPartitionValidate(candidate, &error)) {
                 continue;
@@ -450,7 +452,8 @@ bool launcherSelectInstallLayout(
                             candidateSpiffs,
                             candidateHasSpiffs,
                             candidateFats,
-                            error
+                            error,
+                            spiffsLabel
                         ) ||
                         !launcherPartitionValidate(candidate, &error)) {
                         continue;

--- a/src/partition_install_layout.h
+++ b/src/partition_install_layout.h
@@ -17,13 +17,15 @@ struct LauncherInstallFatPartition {
 
 bool launcherPrepareInstallDataPartitions(
     LauncherPartitionTable &table, bool spiffs, uint32_t spiffsSize, LauncherPartitionEntry &spiffsEntry,
-    bool &hasSpiffsEntry, std::vector<LauncherInstallFatPartition> &fatPartitions, String &error
+    bool &hasSpiffsEntry, std::vector<LauncherInstallFatPartition> &fatPartitions, String &error,
+    const String &spiffsLabel = "spiffs"
 );
 
 bool launcherSelectInstallLayout(
     LauncherPartitionTable &table, size_t updateSize, const String &defaultLabel, bool spiffs,
     uint32_t spiffsSize, std::vector<LauncherInstallFatPartition> &fatPartitions,
-    LauncherPartitionEntry &appEntry, LauncherPartitionEntry &spiffsEntry, bool &hasSpiffsEntry, String &error
+    LauncherPartitionEntry &appEntry, LauncherPartitionEntry &spiffsEntry, bool &hasSpiffsEntry, String &error,
+    const String &spiffsLabel = "spiffs"
 );
 
 #endif

--- a/src/partition_table_model.cpp
+++ b/src/partition_table_model.cpp
@@ -793,8 +793,13 @@ bool launcherPartitionIsReplaceableApp(const LauncherPartitionEntry &entry) {
 bool launcherPartitionIsRemovableInstallData(const LauncherPartitionEntry &entry) {
     if (!entry.isData()) return false;
     if (entry.subtype != 0x81 && entry.subtype != 0x82 && entry.subtype != 0x83) return false;
-    return strcmp(entry.label, "spiffs") == 0 || strcmp(entry.label, "sys") == 0 ||
-           strcmp(entry.label, "vfs") == 0;
+    // FAT partitions are only removable if they use the standard install labels
+    if (entry.subtype == 0x81) {
+        return strcmp(entry.label, "sys") == 0 || strcmp(entry.label, "vfs") == 0;
+    }
+    // SPIFFS / LittleFS partitions are removable regardless of label
+    // (e.g. "spiffs", "assets", "storage", etc.)
+    return true;
 }
 
 bool launcherPartitionRemoveInstallDataPartitions(LauncherPartitionTable &table, bool removeSpiffs) {

--- a/src/sd_functions.cpp
+++ b/src/sd_functions.cpp
@@ -546,7 +546,8 @@ static uint32_t effectiveSdAppSize(File &file, uint32_t appOffset, uint32_t fall
 
 static bool installFromSdDynamic(
     File &file, const String &path, uint32_t appSize, uint32_t appOffset, bool spiffs, uint32_t spiffsOffset,
-    uint32_t spiffsSize, uint32_t spiffsCopySize, std::vector<LauncherInstallFatPartition> &fatPartitions
+    uint32_t spiffsSize, uint32_t spiffsCopySize, std::vector<LauncherInstallFatPartition> &fatPartitions,
+    const String &spiffsLabel
 ) {
     String error;
     LauncherPartitionTable table;
@@ -577,7 +578,8 @@ static bool installFromSdDynamic(
             appEntry,
             spiffsEntry,
             hasSpiffsEntry,
-            error
+            error,
+            spiffsLabel
         )) {
         launcherConsolePrintf("SD install layout failed: %s\n", error.c_str());
         displayRedStripe(error.length() ? error : "No install space");
@@ -677,6 +679,7 @@ void updateFromSD(String path) {
     uint32_t app_size = 0;
     uint32_t app_offset = 0;
     bool spiffs = false;
+    String spiffsLabel = "spiffs";
     std::vector<LauncherInstallFatPartition> fatPartitions;
 
     File file = SDM.open(path);
@@ -688,7 +691,7 @@ void updateFromSD(String path) {
     if (partitionEntry[0] != 0xAA || partitionEntry[1] != 0x50 || partitionEntry[2] != 0x01) {
         app_size = effectiveSdAppSize(file, 0, file.size());
         std::vector<LauncherInstallFatPartition> fatPartitions;
-        if (!installFromSdDynamic(file, path, app_size, 0, false, 0, 0, 0, fatPartitions)) { goto Exit; }
+        if (!installFromSdDynamic(file, path, app_size, 0, false, 0, 0, 0, fatPartitions, spiffsLabel)) { goto Exit; }
         file.close();
         tft->fillScreen(BGCOLOR);
         FREE_TFT
@@ -724,7 +727,7 @@ void updateFromSD(String path) {
                 }
             }
 
-            if (partitionEntry[0x02] == 0x01 && partitionEntry[3] == 0x82) {
+            if (partitionEntry[0x02] == 0x01 && (partitionEntry[3] == 0x82 || partitionEntry[3] == 0x83)) {
                 spiffs_offset = readLe32(partitionEntry + 0x04);
                 const uint32_t declaredSpiffsSize = readLe32(partitionEntry + 0x08);
                 spiffs_size = declaredSpiffsSize > LAUNCHER_DEFAULT_SPIFFS_THRESHOLD
@@ -738,6 +741,8 @@ void updateFromSD(String path) {
                                                                               : spiffs_size
                 );
                 spiffs = true;
+                String declaredLabel = readPartitionLabel(partitionEntry);
+                if (!declaredLabel.isEmpty()) spiffsLabel = declaredLabel;
                 if (file.size() < spiffs_offset) {
                     spiffs_copy_size = 0;
                     launcherConsolePrintf(
@@ -809,7 +814,8 @@ void updateFromSD(String path) {
                 spiffs_offset,
                 spiffs_size,
                 spiffs_copy_size,
-                fatPartitions
+                fatPartitions,
+                spiffsLabel
             )) {
             goto Exit;
         }


### PR DESCRIPTION
## Problem

M5Launcher currently hardcodes the SPIFFS data partition label as "spiffs" during firmware installation, ignoring the actual label defined in the merged binary's partition table. Firmware that uses a custom label (e.g. "assets") for its data partition fails after install — the partition is created with the wrong label, so the app's `esp_partition_find_first()` call cannot find it.

## Changes

- **Extract actual partition label** from partition table entries when parsing merged binaries (all 3 install paths: OTA URL, SD card, LauncherHub manifest)
- **Pass the extracted label** through the entire install chain (`installFirmware` -> `installFirmwareDynamic` -> `launcherSelectInstallLayout` -> `launcherPrepareInstallDataPartitions`)
- **Treat any SPIFFS (0x82) / LittleFS (0x83) partition** as removable install data regardless of label (previously only "spiffs", "sys", "vfs" were considered removable)
- **Add `littlefs` subtype support** in LauncherHub manifest parsing
- **Default all new parameters** to "spiffs" for full backward compatibility

## Files changed

| File | Change |
|:-----|:-------|
| `src/onlineLauncher.cpp` / `.h` | Label extraction from partition table; parameter plumbing |
| `src/sd_functions.cpp` | Label extraction for SD installs; support subtype 0x83 |
| `src/partition_install_layout.cpp` / `.h` | Replace hardcoded "spiffs" with parameterized label |
| `src/partition_table_model.cpp` | Make SPIFFS/LittleFS partitions removable regardless of label |

## Backward compatibility

All new function parameters default to `"spiffs"`, so existing callers and existing firmware with standard "spiffs" partitions continue to work unchanged.

## Testing

- [x] Code review: all hardcoded "spiffs" references in the install path replaced
- [x] CI build passes for all boards

---

This unlocks compatibility with any firmware using non-standard SPIFFS/LittleFS partition labels.