### PR TITLE
fix: clear menu button hover residue at top-left and bottom-right corners

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -873,6 +873,9 @@ void drawMainMenu(std::vector<MenuOptions> &opt, int index) {
                     drawH = h;
                 }
             }
+            // Clear residue from previous selected state: top-left (button) and bottom-right (shadow)
+            tft->fillRect(x, y, 4, 4, BGCOLOR);
+            tft->fillRect(x + w - 4, y + h - 4, 4, 4, BGCOLOR);
             // Non-selected item
             tft->drawRoundRect(drawX, drawY, drawW, drawH, 5, BGCOLOR);
             tft->drawRoundRect(drawX + 1, drawY + 1, drawW - 2, drawH - 2, 5, BGCOLOR);


### PR DESCRIPTION
## Problem

In `drawMainMenu()`, when a button goes from **selected** to **non-selected**, pixel residue remains visible at the **top-left** and **bottom-right** corners of the button area.

## Root cause

**Selected state** draws:
- `fillRoundRect(x, y, w-6, h-6, 5, selectedColor)` — the button
- `fillRoundRect(x+6, y+6, w-6, h-6, 5, DARKGREY)` — the shadow

**Non-selected state** only clears the inner area:
- `fillRoundRect(x+3, y+3, w-6, h-6, 5, BGCOLOR)`

The outer 3px border is only covered by 1px `drawRoundRect` outlines in `BGCOLOR`, which don't fully clear anti-aliased pixels or the shadow fill.

## Fix

Add two targeted `fillRect` clears in `BGCOLOR` before drawing the non-selected button:
- Top-left corner: `fillRect(x, y, 4, 4, BGCOLOR)`
- Bottom-right corner: `fillRect(x+w-4, y+h-4, 4, 4, BGCOLOR)`

This is minimal and avoids a full `fillRoundRect` clear of the entire button area.