### PR TITLE
fix(tab5): add missing psram_mode oct — fixes black screen on boot

### DIFF
--- a/boards/_jsonfiles/m5stack-tab5.json
+++ b/boards/_jsonfiles/m5stack-tab5.json
@@ -10,6 +10,7 @@
     "f_cpu": "360000000L",
     "f_flash": "80000000L",
     "f_psram": "200000000L",
+    "psram_mode": "oct",
     "flash_mode": "qio",
     "mcu": "esp32p4",
     "chip_variant": "esp32p4_es",


### PR DESCRIPTION
The M5Stack Tab5 uses octal PSRAM (8 data lines). Without explicit psram_mode in the board JSON, Arduino-ESP32 defaults to quad mode (4 lines), causing a hard crash on first PSRAM access — black screen, device appears dead.

## The fix
Add `"psram_mode": "oct"` to `boards/_jsonfiles/m5stack-tab5.json`.

## Why this matters
- Factory firmware works because ESP-IDF sdkconfig has `CONFIG_SPIRAM_MODE_OCT=y`
- The xiaozhi-esp32 Tab5 board config has it set correctly
- M5Launcher was the only Tab5 firmware missing this, making it appear broken

## Tested
Built via `pio run -e m5stack-tab5`, flashed to Tab5 hardware, boots to launcher menu successfully.