### PR TITLE
tab5: psram mode + partition table fixes

### DIFF
--- a/boards/_jsonfiles/m5stack-tab5.json
+++ b/boards/_jsonfiles/m5stack-tab5.json
@@ -10,6 +10,7 @@
     "f_cpu": "360000000L",
     "f_flash": "80000000L",
     "f_psram": "200000000L",
+    "psram_mode": "oct",
     "flash_mode": "qio",
     "mcu": "esp32p4",
     "chip_variant": "esp32p4_es",

--- a/support_files/custom_16Mb_p4.csv
+++ b/support_files/custom_16Mb_p4.csv
@@ -1,6 +1,7 @@
-# Name,     Type, SubType,   Offset,   Size,    Flags
-nvs,        data, nvs,       0x9000,   0x4000,
-otadata,    data, ota,       0xD000,   0x2000,
-phy_init,   data, phy,       0xf000,   0x1000,
-app0,       app,  factory,   0x10000,  0x180000,
-coredump,   data, coredump,  0x190000, 0x10000,
+# Name,     Type, SubType,   Offset,   Size,      Flags
+nvs,        data, nvs,       0x9000,   0x6000,
+otadata,    data, ota,       0xf000,   0x2000,
+phy_init,   data, phy,       0x11000,  0x1000,
+factory,    app,  factory,   0x20000,  0x300000,
+ota_0,      app,  ota_0,     0x320000, 0x400000,
+assets,     data, spiffs,    0x720000, 0x8E0000,


### PR DESCRIPTION
I was having trouble getting my Tab5 to boot Launcher and install firmware, here's what I found helpful and working for me.

Two changes:

**psram_mode: oct** — Without this the Tab5 black-screens on boot. The Tab5 uses octal PSRAM but the default for ESP32-P4 is quad. Factory firmware and xiaozhi have this set right but the launcher board JSON was missing it.

**Partition table** — The existing one only had a factory app partition. The launcher needs OTA slots to install firmware to (isOtaApp() check in partition_table_model.cpp). I added ota_0 (4MB) and an assets partition at the label xiaozhi expects, since that's what a lot of Tab5 firmware looks for.

Built and tested on my Tab5 — launcher boots, touch works, firmware installs and launches. The mac emulator runs great through it.

Happy to adjust anything that doesn't fit how you want it set up.