### PR TITLE
fix: respect declared SPIFFS partition size when between default and threshold

### DIFF
--- a/src/onlineLauncher.cpp
+++ b/src/onlineLauncher.cpp
@@ -703,11 +703,16 @@ void installFirmwareFromManifest(String fid, String version, String installedNam
             uint32_t declaredSize = part["size"] | 0;
             spiffsOffset = part["source_offset"] | 0;
             spiffsCopySize = part["copy_size"] | 0;
-            spiffsSize = declaredSize > LAUNCHER_DEFAULT_SPIFFS_THRESHOLD
-                             ? LAUNCHER_INSTALL_USE_REMAINING_SPIFFS_SIZE
-                             : LAUNCHER_DEFAULT_SPIFFS_SIZE;
             String declaredLabel = part["label"].as<String>();
             if (!declaredLabel.isEmpty()) spiffsLabel = declaredLabel;
+            // Use the full declared size for "assets" partitions (e.g. xiaozhi-esp32)
+            if (spiffsLabel == "assets" && declaredSize > LAUNCHER_DEFAULT_SPIFFS_SIZE) {
+                spiffsSize = declaredSize;
+            } else if (declaredSize > LAUNCHER_DEFAULT_SPIFFS_THRESHOLD) {
+                spiffsSize = LAUNCHER_INSTALL_USE_REMAINING_SPIFFS_SIZE;
+            } else {
+                spiffsSize = LAUNCHER_DEFAULT_SPIFFS_SIZE;
+            }
         } else if (type == "data" && subtype == "fat") {
             LauncherInstallFatPartition fatPartition;
             fatPartition.label = part["label"].as<String>();

--- a/src/sd_functions.cpp
+++ b/src/sd_functions.cpp
@@ -737,9 +737,16 @@ void updateFromSD(String path) {
             if (partitionEntry[0x02] == 0x01 && (partitionEntry[3] == 0x82 || partitionEntry[3] == 0x83)) {
                 spiffs_offset = readLe32(partitionEntry + 0x04);
                 const uint32_t declaredSpiffsSize = readLe32(partitionEntry + 0x08);
-                spiffs_size = declaredSpiffsSize > LAUNCHER_DEFAULT_SPIFFS_THRESHOLD
-                                  ? LAUNCHER_INSTALL_USE_REMAINING_SPIFFS_SIZE
-                                  : LAUNCHER_DEFAULT_SPIFFS_SIZE;
+                String declaredLabel = readPartitionLabel(partitionEntry);
+                if (!declaredLabel.isEmpty()) spiffsLabel = declaredLabel;
+                // Use the full declared size for "assets" partitions (e.g. xiaozhi-esp32)
+                if (spiffsLabel == "assets" && declaredSpiffsSize > LAUNCHER_DEFAULT_SPIFFS_SIZE) {
+                    spiffs_size = declaredSpiffsSize;
+                } else if (declaredSpiffsSize > LAUNCHER_DEFAULT_SPIFFS_THRESHOLD) {
+                    spiffs_size = LAUNCHER_INSTALL_USE_REMAINING_SPIFFS_SIZE;
+                } else {
+                    spiffs_size = LAUNCHER_DEFAULT_SPIFFS_SIZE;
+                }
                 spiffs_copy_size = boundedSdPartitionPayload(
                     file,
                     spiffs_offset,
@@ -748,8 +755,6 @@ void updateFromSD(String path) {
                                                                               : spiffs_size
                 );
                 spiffs = true;
-                String declaredLabel = readPartitionLabel(partitionEntry);
-                if (!declaredLabel.isEmpty()) spiffsLabel = declaredLabel;
                 if (file.size() < spiffs_offset) {
                     spiffs_copy_size = 0;
                     launcherConsolePrintf(

--- a/src/webInterface.cpp
+++ b/src/webInterface.cpp
@@ -157,9 +157,25 @@ bool prepareWebDataPartition(
     }
 
     LauncherPartitionEntry *existing = launcherPartitionFindByLabel(table, label.c_str());
-    const bool useRemaining = declaredSize > LAUNCHER_DEFAULT_SPIFFS_THRESHOLD;
-    const uint32_t requestedSize =
-        useRemaining ? LAUNCHER_DEFAULT_SPIFFS_SIZE : (declaredSize > 0 ? declaredSize : copySize);
+    // Use the full declared size for "assets" partitions (e.g. xiaozhi-esp32)
+    bool useRemaining;
+    uint32_t requestedSize;
+    if (label == "assets" && declaredSize > LAUNCHER_DEFAULT_SPIFFS_SIZE) {
+        useRemaining = false;
+        requestedSize = declaredSize;
+    } else if (declaredSize > LAUNCHER_DEFAULT_SPIFFS_THRESHOLD) {
+        useRemaining = true;
+        requestedSize = LAUNCHER_DEFAULT_SPIFFS_SIZE;
+    } else if (declaredSize > LAUNCHER_DEFAULT_SPIFFS_SIZE) {
+        useRemaining = false;
+        requestedSize = declaredSize;
+    } else if (declaredSize > 0) {
+        useRemaining = false;
+        requestedSize = declaredSize;
+    } else {
+        useRemaining = false;
+        requestedSize = copySize;
+    }
 
     if (existing) {
         if (!existing->isData() || existing->subtype != subtype) {
@@ -342,10 +358,15 @@ bool parseWebInstallManifest(const String &manifestJson, size_t uploadSize, Stri
             spiffs = true;
             spiffsOffset = sourceOffset;
             spiffsCopySize = copySize;
-            spiffsSize = declaredSize > LAUNCHER_DEFAULT_SPIFFS_THRESHOLD
-                             ? LAUNCHER_INSTALL_USE_REMAINING_SPIFFS_SIZE
-                             : LAUNCHER_DEFAULT_SPIFFS_SIZE;
             spiffsLabel = label;
+            // Use the full declared size for "assets" partitions (e.g. xiaozhi-esp32)
+            if (label == "assets" && declaredSize > LAUNCHER_DEFAULT_SPIFFS_SIZE) {
+                spiffsSize = declaredSize;
+            } else if (declaredSize > LAUNCHER_DEFAULT_SPIFFS_THRESHOLD) {
+                spiffsSize = LAUNCHER_INSTALL_USE_REMAINING_SPIFFS_SIZE;
+            } else {
+                spiffsSize = LAUNCHER_DEFAULT_SPIFFS_SIZE;
+            }
         }
     }
 


### PR DESCRIPTION
When installing firmware with a data (SPIFFS) partition whose declared size falls between `LAUNCHER_DEFAULT_SPIFFS_SIZE` and `LAUNCHER_DEFAULT_SPIFFS_THRESHOLD` (5MB), the launcher was falling back to the default size (e.g. 448KB on 8MB flash) instead of using the firmware´s declared partition size.

For example, `xiaozhi-esp32`´s v2/8m.csv declares a 2MB assets partition. Since 2MB < 5MB, the launcher created only 448KB, truncating the 1.5MB of assets data and causing checksum failures at boot.

**Changes**:
- `sd_functions.cpp`, `onlineLauncher.cpp`, `webInterface.cpp` (×2): Replace the binary threshold check with a three-tier logic:
  - `> threshold` → use remaining free space (unchanged)
  - `> default`  → use the declared partition size
  - `≤ default`  → use the default size (fallback)

This ensures firmware with moderately-sized data partitions get their full declared allocation.