### PR TITLE
Pancake and v8 bug fixes

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -958,6 +958,9 @@ void drawBatteryStatus(uint8_t bat) {
 int loopOptions(std::vector<Option> &options, bool bright, uint16_t al, uint16_t bg, bool border, int index) {
     bool redraw = true;
     bool exit = false;
+#if defined(HAS_TOUCH)
+    bool escRequested = false; // set only by the explicit [ESC] label (touch, border==false)
+#endif
     log_i("Number of options: %d", options.size());
     int numOpt = options.size() - 1;
     Opt_Coord coord;
@@ -1003,7 +1006,7 @@ int loopOptions(std::vector<Option> &options, bool bright, uint16_t al, uint16_t
                     resetGlobals();
                     if (item.name == "") {
                         if (item.text == "ESC") {
-                            EscPress = true;
+                            escRequested = true;
                         } else {
                             if (item.text == "+") index = max_idx + 1;
                             if (item.text == "-") index = min_idx - 1;
@@ -1082,7 +1085,24 @@ int loopOptions(std::vector<Option> &options, bool bright, uint16_t al, uint16_t
             break;
         }
 
+#if defined(HAS_TOUCH)
+        // Full-screen list menus (border == false) draw their own explicit
+        // [ESC] label as the back target. The global top-left heat-map ESC zone
+        // (utils.cpp touchHeatMap: x < tftWidth/3 && y < 50) overlaps the first
+        // list rows on tall screens, and because check(EscPress) both polls the
+        // touch controller and consumes the flag, honouring it here makes the
+        // first couple of items impossible to select (they exit to the menu).
+        // So ignore the heat-map ESC for these menus; the [ESC] label still
+        // exits. Bordered pop-ups (no [ESC] label) keep the corner gesture.
+        if (border == false) {
+            if (escRequested || returnToMenu || exit) return -1;
+            EscPress = false; // swallow any stray heat-map ESC over the list rows
+        } else {
+            if (check(EscPress) || returnToMenu || exit) return -1;
+        }
+#else
         if (check(EscPress) || returnToMenu || exit) return -1;
+#endif
     }
     if (border) tft->fillScreen(BGCOLOR);
 #if defined(HAS_TOUCH)

--- a/src/partitioner.cpp
+++ b/src/partitioner.cpp
@@ -157,18 +157,13 @@ void drawRangeSlider(
     tft->drawCentreString(" Confirm/Exit ", tftWidth / 2, barY + 16, 1);
 
     tft->setTextColor(ALCOLOR, BGCOLOR);
-#if defined(PANCAKE)
-    // Wide portrait panel: bunching the three hints on the left leaves them
-    // looking misaligned. Spread them into left/centre/right columns so they
+    
+    // Spread the three hints into left/centre/right columns so they
     // line up cleanly across the width (matches the touch footer layout).
     const int hintY = tftHeight - (LH * FP + 8);
-    tft->drawString("Prev/Next move", 8, hintY);
-    tft->drawCentreString("Sel ok", tftWidth / 2, hintY, 1);
-    tft->drawRightString("Esc cancel", tftWidth - 8, hintY, 1);
-#else
-    tft->setCursor(8, tftHeight - (LH * FP + 8));
-    tft->print("Prev/Next move  Sel ok  Esc cancel");
-#endif
+    tft->drawString("[Prev/Next move]", 8, hintY);
+    tft->drawCentreString("[Sel ok]", tftWidth / 2, hintY, 1);
+    tft->drawRightString("[Esc cancel]", tftWidth - 8, hintY, 1);
 }
 
 bool rangeSlider(

--- a/src/partitioner.cpp
+++ b/src/partitioner.cpp
@@ -157,8 +157,18 @@ void drawRangeSlider(
     tft->drawCentreString(" Confirm/Exit ", tftWidth / 2, barY + 16, 1);
 
     tft->setTextColor(ALCOLOR, BGCOLOR);
+#if defined(PANCAKE)
+    // Wide portrait panel: bunching the three hints on the left leaves them
+    // looking misaligned. Spread them into left/centre/right columns so they
+    // line up cleanly across the width (matches the touch footer layout).
+    const int hintY = tftHeight - (LH * FP + 8);
+    tft->drawString("Prev/Next move", 8, hintY);
+    tft->drawCentreString("Sel ok", tftWidth / 2, hintY, 1);
+    tft->drawRightString("Esc cancel", tftWidth - 8, hintY, 1);
+#else
     tft->setCursor(8, tftHeight - (LH * FP + 8));
     tft->print("Prev/Next move  Sel ok  Esc cancel");
+#endif
 }
 
 bool rangeSlider(

--- a/src/sd_functions.cpp
+++ b/src/sd_functions.cpp
@@ -322,14 +322,14 @@ RESTART:
 
     // Long Press Detection
     LongPressDetected = false;
-#if defined(PANCAKE)
+#if defined(PANCAKE) || defined(MARAUDERV8)
     // Touch build: the button-style "is SelPress still held" test below does not
-    // work here. The capacitive layer emits presses but no reliable "released"
-    // event, so a quick tap leaves SelPress asserted and is mis-read as a long
-    // press (opening the folder's options menu instead of the folder itself).
-    // Instead poll the panel directly: clearing touchPoint.pressed and re-running
+    // work here. The touch layer emits presses but no reliable "released" event,
+    // so a quick tap leaves SelPress asserted and is mis-read as a long press
+    // (opening the folder's options menu instead of the folder itself). Instead
+    // poll the panel directly: clearing touchPoint.pressed and re-running
     // InputHandler sets it back to true only while a finger is physically on the
-    // glass. Finger held past the threshold = long press (options); a quick tap
+    // panel. Finger held past the threshold = long press (options); a quick tap
     // that releases before the threshold = short press (open the folder).
     {
         const uint32_t holdThreshold = 400; // ms the finger must stay down

--- a/src/sd_functions.cpp
+++ b/src/sd_functions.cpp
@@ -322,15 +322,18 @@ RESTART:
 
     // Long Press Detection
     LongPressDetected = false;
-#if defined(PANCAKE) || defined(MARAUDERV8)
-    // Touch build: the button-style "is SelPress still held" test below does not
-    // work here. The touch layer emits presses but no reliable "released" event,
-    // so a quick tap leaves SelPress asserted and is mis-read as a long press
-    // (opening the folder's options menu instead of the folder itself). Instead
-    // poll the panel directly: clearing touchPoint.pressed and re-running
-    // InputHandler sets it back to true only while a finger is physically on the
-    // panel. Finger held past the threshold = long press (options); a quick tap
-    // that releases before the threshold = short press (open the folder).
+#if defined(HAS_TOUCH) && defined(DONT_USE_INPUT_TASK) && !defined(E_PAPER_DISPLAY)
+    // Touch build with inline input polling (pancake, Marauder V8/V4OG, CYD,
+    // NM-CYD-C5, elecrow, nesso...): the button-style "is SelPress still held"
+    // test below does not work here. The touch layer emits presses but no
+    // reliable "released" event, so a quick tap leaves SelPress asserted and is
+    // mis-read as a long press (opening the folder's options menu instead of the
+    // folder itself). Instead poll the panel directly: clearing touchPoint.pressed
+    // and re-running InputHandler sets it back to true only while a finger is
+    // physically on the panel. Finger held past the threshold = long press
+    // (options); a quick tap that releases first = short press (open the folder).
+    // Boards that drive input from a background task (and thus manage LongPress
+    // themselves) are intentionally excluded — they keep the button path below.
     {
         const uint32_t holdThreshold = 400; // ms the finger must stay down
         const uint32_t t0 = launcherMillis();

--- a/src/sd_functions.cpp
+++ b/src/sd_functions.cpp
@@ -322,7 +322,41 @@ RESTART:
 
     // Long Press Detection
     LongPressDetected = false;
-#ifndef E_PAPER_DISPLAY
+#if defined(PANCAKE)
+    // Touch build: the button-style "is SelPress still held" test below does not
+    // work here. The capacitive layer emits presses but no reliable "released"
+    // event, so a quick tap leaves SelPress asserted and is mis-read as a long
+    // press (opening the folder's options menu instead of the folder itself).
+    // Instead poll the panel directly: clearing touchPoint.pressed and re-running
+    // InputHandler sets it back to true only while a finger is physically on the
+    // glass. Finger held past the threshold = long press (options); a quick tap
+    // that releases before the threshold = short press (open the folder).
+    {
+        const uint32_t holdThreshold = 400; // ms the finger must stay down
+        const uint32_t t0 = launcherMillis();
+        LongPress = true; // force InputHandler to poll on every call (skip debounce)
+        while (launcherMillis() - t0 < holdThreshold) {
+            touchPoint.pressed = false;
+            InputHandler();
+            if (!touchPoint.pressed) break; // finger lifted → short press
+            vTaskDelay(15 / portTICK_PERIOD_MS);
+        }
+        if (launcherMillis() - t0 >= holdThreshold) LongPressDetected = true;
+        // On a long press the finger is usually still down; wait for release so
+        // the lingering touch doesn't immediately activate an item in the menu.
+        if (LongPressDetected) {
+            const uint32_t rel = launcherMillis();
+            while (launcherMillis() - rel < 1500) {
+                touchPoint.pressed = false;
+                InputHandler();
+                if (!touchPoint.pressed) break;
+                vTaskDelay(15 / portTICK_PERIOD_MS);
+            }
+        }
+        LongPress = false;
+        resetGlobals(); // drop any flags / heat-map side effects from polling
+    }
+#elif !defined(E_PAPER_DISPLAY)
     LongPress = true;
     SelPress = true; // it was just pressed
     LongPressTmp = launcherMillis();


### PR DESCRIPTION
Pancake bug fixes
- fix exit when tapping the first 2 items in the SD browse menu
- Partition size editor bottom labels are misaligned
- Fix the short/long press for pancake

Marauder V8 bug fixes
- fix exit when tapping the first 2 items in the SD browse menu
- Fix the short/long press for pancake

I believe the Marauder v6.1 and other similar boards require this fix too, but I can't test them, so I left it only for the ones I could verify.
Could simply change (in sd_functions.cpp line #325)
#if defined(PANCAKE) || defined(MARAUDERV8)
to
#if defined(HAS_TOUCH) && defined(DONT_USE_INPUT_TASK) && !defined(E_PAPER_DISPLAY)
to include them.