### PR TITLE
Size data partitions to their payload instead of truncating the payload

### DIFF
--- a/src/onlineLauncher.cpp
+++ b/src/onlineLauncher.cpp
@@ -743,6 +743,14 @@ void installFirmwareFromManifest(const String &fid, const String &version, Strin
             } else {
                 dp.partitionSize = LAUNCHER_DEFAULT_SPIFFS_SIZE;
             }
+            // A partition we are about to fill must be able to hold what goes
+            // into it: the copy is clamped to the entry size at install time, so
+            // a default-sized partition silently truncates a larger payload and
+            // the filesystem lands corrupt. Grow to fit whenever there is one.
+            if (dp.partitionSize != LAUNCHER_INSTALL_USE_REMAINING_SPIFFS_SIZE &&
+                dp.copySize > dp.partitionSize) {
+                dp.partitionSize = dp.copySize;
+            }
             dataPartitions.push_back(dp);
         } else if (type == "data" && subtype == "fat") {
             LauncherInstallDataPartition dp;

--- a/src/sd_functions.cpp
+++ b/src/sd_functions.cpp
@@ -787,13 +787,13 @@ void updateFromSD(const String &path) {
                 } else {
                     dp.partitionSize = LAUNCHER_DEFAULT_SPIFFS_SIZE;
                 }
-                dp.copySize = boundedSdPartitionPayload(
-                    file,
-                    dp.sourceOffset,
-                    declaredSize,
-                    dp.partitionSize == LAUNCHER_INSTALL_USE_REMAINING_SPIFFS_SIZE ? declaredSize
-                                                                                   : dp.partitionSize
-                );
+                dp.copySize = boundedSdPartitionPayload(file, dp.sourceOffset, declaredSize, declaredSize);
+                // See the note in onlineLauncher.cpp: size the partition to the
+                // payload rather than truncating the payload to the partition.
+                if (dp.partitionSize != LAUNCHER_INSTALL_USE_REMAINING_SPIFFS_SIZE &&
+                    dp.copySize > dp.partitionSize) {
+                    dp.partitionSize = dp.copySize;
+                }
                 if (file.size() < dp.sourceOffset) {
                     dp.copySize = 0;
                     launcherConsolePrintf(

--- a/src/webInterface.cpp
+++ b/src/webInterface.cpp
@@ -336,6 +336,14 @@ bool parseWebInstallManifest(const String &manifestJson, size_t uploadSize, Stri
             } else {
                 dp.partitionSize = LAUNCHER_DEFAULT_SPIFFS_SIZE;
             }
+            // A partition we are about to fill must be able to hold what goes
+            // into it: the copy is clamped to the entry size at install time, so
+            // a default-sized partition silently truncates a larger payload and
+            // the filesystem lands corrupt. Grow to fit whenever there is one.
+            if (dp.partitionSize != LAUNCHER_INSTALL_USE_REMAINING_SPIFFS_SIZE &&
+                dp.copySize > dp.partitionSize) {
+                dp.partitionSize = dp.copySize;
+            }
         } else {
             continue;
         }


### PR DESCRIPTION
### The problem

When a firmware ships a prebuilt filesystem image, the install plan clamps SPIFFS/LittleFS partitions to `LAUNCHER_DEFAULT_SPIFFS_SIZE` unless the label is `assets` or the declared size is above `LAUNCHER_DEFAULT_SPIFFS_THRESHOLD`. The copy that follows is clamped to the partition it writes into:

```cpp
const uint32_t copySize = dp.copySize > dp.entry.size ? dp.entry.size : dp.copySize;
```

So a payload between the default (1 MB on >8 MB flash) and the threshold (12 MB) is written short — silently. The device boots with a truncated, corrupt filesystem and nothing in the log says why.

### How we ran into it

Our firmware carries a 2.2 MB read-only Unicode font in its own partition. Installed through Launcher it arrived as 1 MB, so the font failed its size check and the firmware fell back to reading the font off an SD card — which costs ~32 KB of heap on an ESP32-S3 without PSRAM and left the device unable to bring up MQTT. It took a while to trace that back to a partition size.

It isn't specific to us: any firmware shipping a populated SPIFFS/LittleFS image in that size range gets the same silent truncation.

### The change

Grow the partition to fit the payload whenever a payload exists. The layout planner already handles allocation and already reports honestly when flash can't accommodate a request, so this only stops the plan from asking for something it knows is too small.

- Partitions **without** a payload keep the default size — unchanged.
- The `USE_REMAINING` case is left alone — unchanged.
- `assets` special-casing still works, it just isn't the only way to get a correct size anymore.

Applied in the three places that build install plans: catalog manifest (`onlineLauncher.cpp`), WebUI upload (`webInterface.cpp`), SD install (`sd_functions.cpp`). The SD path now measures the payload against the declared size first, since it previously bounded it by the already-clamped partition size.

### Testing

Built for `m5stack-cardputer` (the env that covers the ADV). Happy to test other paths or adjust the approach if you'd prefer it scoped differently.