### PR TITLE
fix: re-run board GPIO setup before Mass Storage SD remount (Cardputer ADV)

### DIFF
--- a/src/massStorage.cpp
+++ b/src/massStorage.cpp
@@ -2,6 +2,7 @@
 #include "massStorage.h"
 #include "display.h"
 #include "idf/launcher_platform.h"
+#include "interface.h"
 #include "sd_functions.h"
 #ifdef SOC_USB_OTG_SUPPORTED
 #include "esp_private/usb_phy.h"
@@ -258,6 +259,17 @@ void MassStorage::setup() {
 
     setShouldStop(false);
     SDM.end(); // Forces SDCard mounting again.
+    // Re-run board GPIO setup before remounting: on boards like the
+    // Cardputer ADV, this pin (e.g. GPIO5, the SD SPI CS) can get
+    // disturbed by other peripherals (TCA8418 I2C keyboard controller,
+    // other I2C sensors) between boot and now. _setup_gpio() already
+    // fixes this once at boot (see boards/m5stack-cardputer/interface.cpp,
+    // "Set GPIO5 HIGH for SD card compatibility") but was never called
+    // again before this forced remount, so entering Mass Storage mode
+    // could hit the exact same interference and require a physical card
+    // reseat to recover. Re-running it here (idempotent, board-specific)
+    // fixes that without needing a reseat.
+    _setup_gpio();
     if (!setupSdCard()) {
         displayError("SD card not found.");
         return;


### PR DESCRIPTION
Fixes #379

## Problem

On the Cardputer ADV, entering **Files > Mass Storage** (USB) fails to mount the SD card on the host PC unless the SD card is physically removed and reinserted immediately before entering USB mode.

## Root cause

`boards/m5stack-cardputer/CardputerADV.md` already documents that GPIO5 is the SD card's SPI CS pin on this board, and gets interference from the TCA8418 I2C keyboard controller plus other I2C sensors. The existing fix (`launcherGpioWrite(5, HIGH)` in `_setup_gpio()`) only runs once, at boot.

`MassStorage::setup()` forces a fresh SD remount (`SDM.end()` + `setupSdCard()`) when entering USB mode, but `setupSdCard()` is board-agnostic with no GPIO5 handling — so the same interference recurs there, and reseating the card was the only way to recover.

## Fix

Re-run `_setup_gpio()` right before `setupSdCard()` in `MassStorage::setup()`. It's already declared globally in `include/interface.h` and safe to call again (idempotent GPIO writes). One-line functional change.

## Testing

Built and flashed on a Cardputer ADV that reliably reproduced the issue. Confirmed: USB Mass Storage now mounts on the first try, every time, no card reseat needed.

Only touches board-agnostic `massStorage.cpp` by calling an existing board-provided hook — should be a no-op on boards whose `_setup_gpio()` doesn't touch SD-related pins.