### PR TITLE
Don't retry a request the server already answered (8 minutes of silent progress bar)

### DIFF
--- a/src/onlineLauncher.cpp
+++ b/src/onlineLauncher.cpp
@@ -409,7 +409,12 @@ bool flashRawRangeFromHttp(
             );
         }
         if (httpOk && update.written == imageSize) break;
-        if (update.written == before && response.status >= 400) break;
+        // Any non-2xx that produced no data is the server's answer, not a hiccup:
+        // repeating the request cannot change it. That includes redirects we
+        // failed to follow (3xx with a transport error), which previously fell
+        // through this check and burned all 24 attempts — several minutes of a
+        // motionless progress bar before the error finally surfaced.
+        if (update.written == before && response.status >= 300) break;
         launcherDelayMs(500);
     }
     bool complete = update.written == imageSize;
@@ -434,7 +439,9 @@ bool flashRawRangeFromHttp(
         } else if (!httpOk && response.transport_error != 0) {
             *errorOut = String("HTTP transport error ") + response.transport_error;
         } else if (!httpOk && response.status != 0) {
-            *errorOut = String("HTTP status ") + response.status;
+            *errorOut = response.status >= 300 && response.status < 400
+                            ? String("Redirect ") + response.status + " not followed"
+                            : String("HTTP status ") + response.status;
         } else if (!complete) {
             *errorOut = String("Download incomplete (") + update.written + "/" + imageSize + ")";
         } else {


### PR DESCRIPTION
Found while testing the catalog install you asked me to try in #378.

### What happens

The range-fetch loop breaks early only on `status >= 400`:

```cpp
if (update.written == before && response.status >= 400) break;
```

A redirect the client fails to follow comes back as `status=302` with a transport error — below 400, so it falls through and the loop retries all 24 times at ~19 s each. That's about **eight minutes of a progress bar that never moves**, and only then does the error reach the screen. From the user's side the install looks frozen and then silently returns to the menu.

### The change

Break on any non-2xx that wrote no bytes. That response is the server's answer, not a transient hiccup — repeating the identical request cannot change it. Retries still do their job for transport failures and for partial progress.

Also gives redirects a name in the error text instead of just a bare number.

### Before / after, same device and network

```
before:  HTTP range fetch failed ... status=302 transport_err=28674   x24, ~8 minutes, no message
after:   HTTP range fetch failed ... status=302 transport_err=28674
         Display Red Stripe: APP: HTTP transport error 28674          ~18 seconds, on screen
```

Note this only fixes the *symptom* — the underlying redirect problem is still there and is discussed in #378 (the proxy answers 302 and the device can't open a connection to wherever it points; `sock < 0`). But an install that fails should say so in seconds rather than look hung for eight minutes.

Built for `m5stack-cardputer`, verified on a Cardputer ADV.