### PR TITLE
Keep the screen lit while an install is on it

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -353,7 +353,7 @@ void displayCurrentVersion(
 ** Function name: displayRedStripe
 ** Description:   Display Red Stripe with information
 ***************************************************************************************/
-void displayRedStripe(const String &text, uint16_t fgcolor, uint16_t bgcolor) {
+void displayRedStripe(const String &text, uint16_t fgcolor, uint16_t bgcolor, bool keepAwake) {
     // save tft settings before showing the stripe
     int _size = tft->getTextsize();
     int _x = tft->getCursorX();
@@ -361,6 +361,10 @@ void displayRedStripe(const String &text, uint16_t fgcolor, uint16_t bgcolor) {
     uint16_t _color = tft->getTextcolor();
     uint16_t _bgcolor = tft->getTextbgcolor();
     Serial.println(String("Display Red Stripe: ") + text);
+    // A stripe is put up to be read, so it restarts the idle clock. Long stages —
+    // an HTTP connect, an erase, a retry backoff — otherwise pass without a single
+    // wake, and the user ends up watching an unlit screen for the whole of one.
+    if (keepAwake) wakeUpScreen();
 
 #if E_PAPER_DISPLAY
     bgcolor = BLACK;

--- a/src/display.h
+++ b/src/display.h
@@ -44,8 +44,12 @@ void displayCurrentVersion(
     int versionIndex, JsonArray versions
 );
 uint16_t getComplementaryColor(uint16_t color);
+// keepAwake: a stripe is normally put up to be read, so it restarts the screen-off
+// timer. Pass false where a stripe is repainted on a timer by something that wants
+// the screen to go dark anyway — see chargeMode().
 void displayRedStripe(
-    const String &text, uint16_t fgcolor = getComplementaryColor(BGCOLOR), uint16_t bgcolor = ALCOLOR
+    const String &text, uint16_t fgcolor = getComplementaryColor(BGCOLOR), uint16_t bgcolor = ALCOLOR,
+    bool keepAwake = true
 );
 
 void displayMsg(String txt, bool waitKeyPress = false); // Red Stripe + wait/delay

--- a/src/onlineLauncher.cpp
+++ b/src/onlineLauncher.cpp
@@ -270,7 +270,14 @@ void pauseInputHandlerTask() {
 void resumeInputHandlerTask() {
     if (!xHandle || inputHandlerPauseDepth == 0) return;
     inputHandlerPauseDepth--;
-    if (inputHandlerPauseDepth == 0) vTaskResume(xHandle);
+    if (inputHandlerPauseDepth == 0) {
+        // Time spent suspended is not idle time. checkPowerSaveTime() lives in the very
+        // task we froze, so the screen-off deadline went on ageing with nothing able to
+        // act on it; the first tick after the resume finds it long past and blanks the
+        // display just as the outcome — often an error — reaches the screen.
+        wakeUpScreen();
+        vTaskResume(xHandle);
+    }
 }
 
 bool discardHttpCb(const uint8_t *, size_t, void *) { return true; }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -506,7 +506,10 @@ void chargeMode() {
     unsigned long tmp = 0;
     while (!check(SelPress)) {
         if (launcherMillis() - tmp > 5000) {
-            displayRedStripe(String(getBattery()) + " %");
+            // The whole point of this mode is a device that goes dark on the charger,
+            // so this repaint must not restart the screen-off timer: it comes round
+            // faster than the shortest timeout and would hold the backlight forever.
+            displayRedStripe(String(getBattery()) + " %", getComplementaryColor(BGCOLOR), ALCOLOR, false);
             tmp = launcherMillis();
         }
     }


### PR DESCRIPTION
Second thing I hit while testing the catalog install for #378: the display goes dark in the middle of an install, and the error at the end of a failed one is gone before you can read it.

### Why

The screen-off timer (`previousMillis`, `checkPowerSaveTime()` in `src/powerSave.cpp`) is only ever restarted from a key press or from `progressHandler()`. An install has neither for long stretches, so:

1. **Time spent under `vTaskSuspend` counts as idle.** `checkPowerSaveTime()` runs inside `taskInputHandler` (`src/main.cpp:80`) — the very task `pauseInputHandlerTask()` suspends for the whole install. The deadline goes on ageing with nothing able to act on it, so the first tick after `resumeInputHandlerTask()` finds it long past and blanks the screen **exactly when the outcome is shown**. On a failed install that means the error stripe is up for about two seconds and then the display is black. That is most of why my first report on #378 could only say "zero progress, then it offers the install again" — there was a message, I just never got to see it.

2. **Stages that move no bytes never wake it.** An HTTP connect, a flash erase, a retry backoff — no progress ticks, so no wake, even though a banner is sitting on screen for the user to read.

### The change

- `resumeInputHandlerTask()` restarts the idle clock before resuming. Time spent suspended is not idle time.
- `displayRedStripe()` restarts it too: a stripe is put up to be read, so every stage gets its full timeout from the moment it announces itself.

### One carve-out, worth flagging

Waking from the stripe on its own would have broken **Charge Mode**. `chargeMode()` (`src/settings.cpp:499`) repaints the battery percentage every 5 s in a loop that only a keypress exits — sooner than the shortest timeout the menu offers (10 s) — so the backlight would have stayed on for as long as the device sat on the charger, which is the opposite of what that mode is for. It now passes `keepAwake=false`.

I went through every other `displayRedStripe`/`displayError` call inside a loop; the rest are event-driven and fire once (`webInterface.cpp:2026` is gated on `updateFromSd_var`, `onlineLauncher.cpp:1014` draws once and then waits), so the parameter defaults to `true`.

### What it does not do

A single stage that stalls past the timeout without a banner of its own will still go dark. Covering that needs an explicit keep-awake held across the operation, which is a bigger change than this warrants — happy to do it that way instead if you'd prefer.

### Tested

Built for `m5stack-cardputer`, on a Cardputer ADV:

- install: screen stays lit throughout, and a failed install leaves its error readable instead of blanking after ~2 s;
- back on the menu afterwards the normal timeout still applies (screen dims and goes off as before);
- Charge Mode still goes fully dark on schedule.