### PR TITLE
The /proxy fallback in 72d8289 could never be reached

### DIFF
--- a/src/onlineLauncher.cpp
+++ b/src/onlineLauncher.cpp
@@ -402,8 +402,6 @@ bool flashRawRangeFromHttp(
     LauncherHttpResponse response;
     String activeUrl = url;
     bool triedProxyFallback = false;
-    uint8_t redirectFailStreak = 0;
-    constexpr uint8_t kProxyFallbackThreshold = 2;
     constexpr uint8_t maxAttempts = 24;
     for (uint8_t attempt = 0; update.written < imageSize && attempt < maxAttempts; ++attempt) {
         size_t before = update.written;
@@ -429,32 +427,24 @@ bool flashRawRangeFromHttp(
         if (update.written == before) {
             const bool unfollowedRedirect = response.status >= 300 && response.status < 400;
             if (unfollowedRedirect) {
-                ++redirectFailStreak;
                 // A redirect the device can't follow is api.launcherhub.net's answer,
-                // not a transient hiccup on the CDN side — the /download endpoint always
-                // sends the same Location. After a couple of tries, fall back to /proxy,
-                // where api.launcherhub.net fetches the CDN itself and streams the bytes
-                // back, so the device never has to open that second connection.
-                if (!triedProxyFallback && redirectFailStreak >= kProxyFallbackThreshold &&
-                    activeUrl.indexOf("/download?") >= 0) {
+                // not a transient hiccup on the CDN side: /download sends the same
+                // Location every time, so trying it again cannot change anything. Switch
+                // to /proxy, where api.launcherhub.net fetches the CDN itself and streams
+                // the bytes back, and the device never opens that second connection at
+                // all. If /proxy redirects too, there is nothing left to try.
+                if (!triedProxyFallback && activeUrl.indexOf("/download?") >= 0) {
                     activeUrl.replace("/download?", "/proxy?");
                     triedProxyFallback = true;
-                    redirectFailStreak = 0;
-                    launcherConsolePrintf(
-                        "Redirect not followed after %u attempts, falling back to /proxy\n",
-                        kProxyFallbackThreshold
-                    );
+                    launcherConsolePrintln("Redirect not followed, falling back to /proxy");
                 } else {
                     break;
                 }
-            } else {
+            } else if (response.status >= 400) {
                 // Any other non-2xx that produced no data is a definitive answer
                 // (repeating it cannot change it), whether from /download or /proxy.
-                if (response.status >= 400) break;
-                redirectFailStreak = 0;
+                break;
             }
-        } else {
-            redirectFailStreak = 0;
         }
         launcherDelayMs(500);
     }


### PR DESCRIPTION
Flashed 72d8289 and the catalogue install failed exactly as before — no `/proxy` line in the log at all. The fallback is unreachable, and my #382 is what made it so.

### The trace

```cpp
if (unfollowedRedirect) {
    ++redirectFailStreak;                       // 1
    if (!triedProxyFallback && redirectFailStreak >= kProxyFallbackThreshold  // 1 >= 2 → false
        && activeUrl.indexOf("/download?") >= 0) {
        ...                                     // never runs
    } else {
        break;                                  // ← leaves on the FIRST redirect
    }
}
```

The threshold of 2 needs a second attempt to happen, and the `else` prevents it. Before #382 a redirect fell through to the retry at the bottom of the loop, which is the second attempt the threshold was written for; #382 made non-2xx responses terminal, so the counter can now only ever reach 1. My apologies — I introduced that interaction and did not think it through when I suggested the streak was merely costing time.

### The change

Counting is not needed at all. `/download` returns the same `Location` every time, so a redirect is the server's answer rather than a hiccup: switch on the first one, and if `/proxy` also redirects there is nothing left to try. The counter, the threshold and the unreachable branch all go away together.

### Verified on hardware

Cardputer ADV, on the network from #378 where TLS 1.2 to the CDN is silently dropped, installing meshtastic-adv from the catalogue:

```
Display Red Stripe: Installing FW
HTTP range fetch failed offset=65536 remaining=2535696 written=0/2535696 status=302 transport_err=28674
Redirect not followed, falling back to /proxy
Display Red Stripe: Installing FW
Display Red Stripe: Installing SPIFFS
Display Red Stripe: Copying Data
HTTP range fetch failed offset=3407872 remaining=2264068 written=0/2264068 status=302 transport_err=28674
Redirect not followed, falling back to /proxy
Display Red Stripe: Copying Data
Display Red Stripe: Writing table
Display Red Stripe: Setting boot
Display Red Stripe: Restarting
```

Both the app image and the 2264068-byte data partition came down through `/proxy`, and the installed firmware booted with its font partition mapped — the first complete catalogue install of this firmware on this network. Your `/proxy` endpoint works exactly as intended; it was only ever the client-side gate.