### PR TITLE
Say when a data partition comes out smaller than declared

### DIFF
--- a/src/onlineLauncher.cpp
+++ b/src/onlineLauncher.cpp
@@ -802,6 +802,7 @@ void installFirmwareFromManifest(const String &fid, const String &version, Strin
             } else {
                 dp.partitionSize = LAUNCHER_DEFAULT_SPIFFS_SIZE;
             }
+            launcherNoteDataPartitionShrink(dp.label, declaredSize, dp.partitionSize);
             dataPartitions.push_back(dp);
         } else if (type == "data" && subtype == "fat") {
             LauncherInstallDataPartition dp;

--- a/src/partition_install_layout.cpp
+++ b/src/partition_install_layout.cpp
@@ -1,8 +1,20 @@
 #include "partition_install_layout.h"
 
 #include "display.h"
+#include "idf/launcher_platform.h"
 
 #include <algorithm>
+
+void launcherNoteDataPartitionShrink(const String &label, uint32_t declaredSize, uint32_t chosenSize) {
+    if (chosenSize == LAUNCHER_INSTALL_USE_REMAINING_SPIFFS_SIZE) return;
+    if (declaredSize == 0 || chosenSize >= declaredSize) return;
+    launcherConsolePrintf(
+        "Data partition '%s': asked %u KB, allocating %u KB (empty filesystem, using the default)\n",
+        label.c_str(),
+        static_cast<unsigned>(declaredSize / 1024),
+        static_cast<unsigned>(chosenSize / 1024)
+    );
+}
 
 bool launcherPrepareInstallDataPartitions(
     LauncherPartitionTable &table,

--- a/src/partition_install_layout.h
+++ b/src/partition_install_layout.h
@@ -20,6 +20,14 @@ struct LauncherInstallDataPartition {
     String sourceUrl;
 };
 
+// Reports, on the console, when a data partition ends up smaller than its manifest or
+// partition table asked for. Every install path deliberately gives an empty filesystem
+// LAUNCHER_DEFAULT_SPIFFS_SIZE regardless of the declared size, which is the right call
+// for the many images that are whole-flash dumps — but a firmware built around a larger
+// filesystem gets it silently, and only finds out by reading its own partition table
+// afterwards. Say it out loud instead; the decision itself is unchanged.
+void launcherNoteDataPartitionShrink(const String &label, uint32_t declaredSize, uint32_t chosenSize);
+
 bool launcherPrepareInstallDataPartitions(
     LauncherPartitionTable &table,
     std::vector<LauncherInstallDataPartition> &dataPartitions,

--- a/src/sd_functions.cpp
+++ b/src/sd_functions.cpp
@@ -878,6 +878,7 @@ void updateFromSD(const String &path) {
                 } else {
                     dp.partitionSize = LAUNCHER_DEFAULT_SPIFFS_SIZE;
                 }
+                launcherNoteDataPartitionShrink(dp.label, declaredSize, dp.partitionSize);
                 dp.copySize = partitionEmpty
                                   ? 0
                                   : boundedSdPartitionPayload(

--- a/src/webInterface.cpp
+++ b/src/webInterface.cpp
@@ -347,6 +347,7 @@ bool parseWebInstallManifest(const String &manifestJson, size_t uploadSize, Stri
             } else {
                 dp.partitionSize = LAUNCHER_DEFAULT_SPIFFS_SIZE;
             }
+            launcherNoteDataPartitionShrink(dp.label, declaredSize, dp.partitionSize);
         } else {
             continue;
         }


### PR DESCRIPTION
An empty filesystem is given `LAUNCHER_DEFAULT_SPIFFS_SIZE` regardless of the size its manifest or partition table declared. That default is right, and this PR does not change it — as you pointed out on #377, most images on M5Burner are whole-flash dumps whose spiffs is empty and huge, and honouring those would hand out megabytes of nothing.

What it changes is that the shrink is currently silent. A firmware genuinely built around a larger filesystem is installed successfully, reports nothing unusual, and runs with a third of the space it was built for. The only way to discover it is to read your own partition table back afterwards, which is exactly how I found it:

```
                       installed          firmware's own table
font   (has payload)   2,293,760          2,293,760     ← honoured
spiffs (empty)           458,752          1,572,864     ← default, silently
```

So: one console line where the size is chosen, in all three paths that choose it (manifest, SD, web). Same allocation as before, just no longer a surprise.

```
Data partition 'spiffs': asked 1536 KB, allocating 448 KB (empty filesystem, using the default)
```

Built for `m5stack-cardputer`.

Separately, and not part of this PR: is there a way you would want a firmware to say "this filesystem is empty, but I need N bytes"? Right now `size` with `copy_size = 0` is indistinguishable from a dump's leftovers, which is what forces the label exceptions you mentioned for `font`. If you have a shape in mind — a manifest flag, an install-time prompt, a size ceiling — I am happy to implement it. If you would rather keep the label list, that is a fine answer too and this PR stands on its own.