### PR TITLE
fix(papermono): avoid startup refresh and frontlight activation

### DIFF
--- a/boards/m5stack-paper-mono/interface.cpp
+++ b/boards/m5stack-paper-mono/interface.cpp
@@ -9,7 +9,11 @@
 #define DW_BTN 3
 
 void _setup_gpio() {
-    M5.begin();
+    M5.Display.setBrightness(0);
+
+    auto cfg = M5.config();
+    cfg.clear_display = false;
+    M5.begin(cfg);
     // UP_BTN -> Prev (single click) / Esc (600ms hold)
     // DW_BTN -> Next (single click) / Sel (600ms hold)
     hal_buttons_init_2(DeviceButtons{DW_BTN, UP_BTN}, 500);


### PR DESCRIPTION
## Summary

First, thank you for adding PaperMono support to Launcher and establishing the integration framework.

While validating the current Beta implementation on real PaperMono hardware, I found two startup behaviors that can be improved without changing the existing Launcher + M5Unified + M5GFX architecture:

- physical E-Ink refresh activity occurs during `M5.begin()` before Launcher
  intentionally renders its first UI frame;
- the PaperMono frontlight is restored to a non-zero brightness during startup.

This patch only adjusts the PaperMono-specific caller configuration.

## PaperMono-specific context

PaperMono is not display-equivalent to PaperS3. It uses an SSD1677 E-Paper display together with M5PM1/M5IOE1-controlled power and peripheral functions.

M5Stack's current PaperMono documentation also notes that:

- the current PaperMono E-Paper waveforms in M5GFX are still considered   unstable, with the manufacturer's OTP example recommended where refresh   stability and panel life are important;
- repeated fast partial refreshes should be managed carefully, with periodic   full refreshes recommended to reduce accumulated ghosting.

For this reason, unnecessary physical refreshes during startup are worth avoiding.

This PR does **not** change the SSD1677 waveform/LUT implementation.

### M5Stack PaperMono E-Paper Driver Notes

<img width="1182" height="349" alt="image" src="https://github.com/user-attachments/assets/a7764f78-4d06-41b7-b764-834bd1dda018" />
M5Stack PaperMono documentation:
https://docs.m5stack.com/en/core/[PaperMono](https://docs.m5stack.com/en/core/PaperMono)

## Hardware evidence

The behavior was reproduced on the same physical M5Stack PaperMono.

### Known-good implementation

<img width="203" height="277" alt="QQ_1787994929952" src="https://github.com/user-attachments/assets/dc965881-9d0f-4dfc-b481-c6478a10cd93" />

After repeated testing on physical PaperMono hardware, I found that keeping the display idle during early initialization and keeping the frontlight off until Launcher applies its own UI policy better matches PaperMono's board-specific startup behavior.

### Current upstream Beta startup behavior

<img width="343" height="242" alt="image" src="https://github.com/user-attachments/assets/04c4e8f4-dbb0-4a71-88f5-1b645ee845a1" />
<img width="348" height="293" alt="image" src="https://github.com/user-attachments/assets/7a9c010e-a1c4-459d-ad28-613428f0510b" /> 
<img width="346" height="252" alt="image" src="https://github.com/user-attachments/assets/d959c8d2-a31a-4b77-b65b-c92ec92753e0" />


Observed during the current upstream startup path:

- visible full-screen black/white E-Paper activity during initialization;
- additional visible refresh activity before a usable Launcher UI was reached;
- the frontlight becoming visibly bright during startup.

Repeated unnecessary E-Paper refreshes and unintended frontlight activation are undesirable during startup, especially on PaperMono where display behavior requires more careful handling than on a conventional continuously refreshed
screen.

M5Stack's own PaperMono documentation already notes that the current M5GFX E-Paper waveforms are still unstable and recommends careful refresh management, including periodic full refreshes after repeated fast partial updates.

For this reason, avoiding unnecessary startup refreshes and keeping the frontlight off until Launcher intentionally applies its own UI policy is a more appropriate startup behavior for PaperMono and helps avoid unnecessary display activity and reduce refresh-related risk over long-term use.

This startup policy is also consistent with behavior that has been exercised successfully during repeated hardware bring-up and validation on physical PaperMono hardware.

## Root cause

The current PaperMono wrapper uses:

```cpp
M5.begin();
```

Runtime diagnostics confirmed that board detection itself is correct:

```text
PM_BDIAG_M5_BOARD=29:M5PaperMono
PM_BDIAG_DISPLAY_BOARD=29:M5PaperMono
PM_BDIAG_PAPERMONO=1
PM_BDIAG_ATOMS3LITE=0
```

The relevant behavior is instead caused by the default startup policy:

1. `clear_display` defaults to `true`, allowing the SSD1677 path to perform
   display clear/update activity during `M5.begin()`.

2. M5Unified restores the stored display brightness during initialization.
   The default non-zero value is mapped by `Light_M5PaperMono` to the
   M5PM1-controlled frontlight.

## Fix

Use the existing public M5Unified/M5GFX APIs:

```cpp
M5.Display.setBrightness(0);

auto cfg = M5.config();
cfg.clear_display = false;
M5.begin(cfg);
```

`clear_display = false` suppresses the generic initialization clear, allowing
Launcher to own the first intended UI refresh.

Setting the stored brightness to `0` before `M5.begin()` causes M5Unified's
normal brightness restore path to restore zero during startup instead of
activating the frontlight.

No M5Unified or M5GFX internal changes are required.

## Scope

The patch is limited to:

```text
boards/m5stack-paper-mono/interface.cpp
5 insertions / 1 deletion
```

It does not introduce:

- a separate PaperMono BSP;
- direct M5PM1/M5IOE1 register access;
- a custom SSD1677 backend;
- changes to M5Unified or M5GFX.

Static review indicates that board autodetection, touch, SD, button handling, power initialization, later UI rendering, and later user-controlled frontlight behavior remain unchanged.

## Validation

- `pio run -e m5stack-paper-mono` — **PASS**
- `git diff --check` — **PASS**
- original behavior reproduced on physical PaperMono hardware
- runtime identity confirmed as `board_M5PaperMono`


Hardware confirmation from another PaperMono test unit would be very helpful.

## Out of scope

This PR intentionally does not address:

- PM1 / IOE1 / IP2315 startup sequencing;
- brownout root cause;
- boot-screen/full-partial refresh policy;
- SSD1677 waveform/LUT behavior.

These can be investigated separately to keep this change small and reviewable.

---

Thanks again for adding PaperMono support to Launcher.

My intention is to preserve the existing upstream architecture and contribute small, evidence-backed PaperMono improvements based on real hardware testing.