### PR TITLE
Fix: don't rewrite off-Hub http:// firmware URLs to the M5 CDN

### DIFF
--- a/src/onlineLauncher.cpp
+++ b/src/onlineLauncher.cpp
@@ -826,7 +826,7 @@ void installFirmwareFromManifest(const String &fid, const String &version, Strin
     }
 
     String fileAddr = buildSourceUrl(fid, file, true);
-    if (!file.startsWith("https://")) file = M5_SERVER_PATH + file;
+    if (!file.startsWith("http")) file = M5_SERVER_PATH + file;
     if (fid == "") fileAddr = file;
 
     String manifestName = detail["name"].as<String>();
@@ -1104,7 +1104,7 @@ static bool padMergedFile(File &file, size_t &pos, size_t target) {
 
 static String buildSourceUrl(const String &fid, const String &sourceUrl, bool useProxy) {
     String url = sourceUrl;
-    if (!url.startsWith("https://")) url = M5_SERVER_PATH + url;
+    if (!url.startsWith("http")) url = M5_SERVER_PATH + url;
     if (useProxy && !fid.isEmpty()) {
         url = String("https://api.launcherhub.net/download?fid=") + fid + "&file=" + url;
     }
@@ -1461,7 +1461,7 @@ void installFirmware(
     std::vector<LauncherInstallDataPartition> &dataPartitions, String installedName
 ) {
     String fileAddr = buildSourceUrl(fid, file, true);
-    if (!file.startsWith("https://")) file = M5_SERVER_PATH + file;
+    if (!file.startsWith("http")) file = M5_SERVER_PATH + file;
     if (fid == "") fileAddr = file;
 
     {


### PR DESCRIPTION
## Problem

Installing firmware from a custom **off-Hub `http://` URL** (a `.bin` on your own
server — LAN, Tailscale, self-hosted) fails: the app fetch 404s at the M5 CDN, even
though the target server serves the file fine (HTTP `206` to the byte-range probe).

`installFirmware`, `installFirmwareFromManifest`, and `buildSourceUrl` prepend
`M5_SERVER_PATH` (`https://m5burner-cdn.m5stack.com/firmware/`) to any URL that
doesn't start with `https://`. A plain `http://` link therefore becomes:

```
https://m5burner-cdn.m5stack.com/firmware/http://host:port/fw.bin   -> 404
```

`installExtFirmware`'s entry guard already accepts `http` (`!url.startsWith("http")`),
and its partition-table probe uses the raw URL — which is why the probe succeeds on
the real server (206) while the app fetch is silently redirected to the CDN. That
mismatch surfaces as a confusing "server returns 206 but the device reports 404".

## Fix

Relax the three `M5_SERVER_PATH` prepend guards from `startsWith("https://")` to
`startsWith("http")`, matching `installExtFirmware`. A full `http://` **or**
`https://` URL is now left untouched; relative / Hub paths (which don't start with
`http`) are still prefixed with the CDN exactly as before, so LauncherHub installs
are unaffected.

Changed in `src/onlineLauncher.cpp`:
- `installFirmwareFromManifest`
- `buildSourceUrl`
- `installFirmware`

## Testing

Verified end-to-end on an **M5Stack Tab5 (ESP32-P4)**: a favorite pointing at
`http://<local-server>/firmware.bin` (a merged image served with byte-range
support) now downloads and installs `village_tab5_car`, where before it failed at
the CDN. LauncherHub / OTA-list installs continue to work unchanged.
