### PR TITLE
Increase uri limit in webui server

### DIFF
--- a/src/idf/idf_web_server.cpp
+++ b/src/idf/idf_web_server.cpp
@@ -9,7 +9,7 @@ httpd_handle_t launcherWebServerStart(uint16_t port) {
     // lru_purge_enable silently killed a queued upload whenever a third connection
     // appeared. LWIP is built with 16 sockets, so five is comfortably within budget.
     config.max_open_sockets = 5;
-    config.max_uri_handlers = 24;
+    config.max_uri_handlers = 32;
     config.lru_purge_enable = true;
     // A queued upload can sit idle while the previous file is written to the SD card;
     // ten seconds was short enough for slow cards to time it out mid-batch. Kept a bit

--- a/src/webInterface.cpp
+++ b/src/webInterface.cpp
@@ -2123,7 +2123,12 @@ void registerHandler(const char *uri, httpd_method_t method, esp_err_t (*handler
     route.method = method;
     route.handler = handler;
     route.user_ctx = nullptr;
-    httpd_register_uri_handler(server, &route);
+    esp_err_t err = httpd_register_uri_handler(server, &route);
+    if (err != ESP_OK) {
+        launcherConsolePrintf(
+            "ERR: Failed to register %s (method %d): %s", uri, method, esp_err_to_name(err)
+        );
+    }
 }
 
 void configureWebServer() {


### PR DESCRIPTION
Primarily fixes "Specified method is invalid for this resource" when creating partitions through webui
See issue #425 
